### PR TITLE
Apply changes to upstream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ config/release/
 
 # Exclude temporary build files
 build/
+.idea/
+vendor/

--- a/PROJECT
+++ b/PROJECT
@@ -1,40 +1,40 @@
-domain: toolkit.fluxcd.io
+domain: qdrant.io
 repo: github.com/fluxcd/source-controller
 resources:
-- group: source
+- group: cd
   kind: GitRepository
   version: v1
-- group: source
+- group: cd
   kind: GitRepository
   version: v1beta2
-- group: source
+- group: cd
   kind: HelmRepository
   version: v1
-- group: source
+- group: cd
   kind: HelmRepository
   version: v1beta2
-- group: source
+- group: cd
   kind: HelmChart
   version: v1
-- group: source
+- group: cd
   kind: HelmChart
   version: v1beta2
-- group: source
+- group: cd
   kind: Bucket
   version: v1beta2
-- group: source
+- group: cd
   kind: GitRepository
   version: v1beta1
-- group: source
+- group: cd
   kind: HelmRepository
   version: v1beta1
-- group: source
+- group: cd
   kind: HelmChart
   version: v1beta1
-- group: source
+- group: cd
   kind: Bucket
   version: v1beta1
-- group: source
+- group: cd
   kind: OCIRepository
   version: v1beta2
 version: "2"

--- a/README.md
+++ b/README.md
@@ -6,6 +6,37 @@
 [![license](https://img.shields.io/github/license/fluxcd/source-controller.svg)](https://github.com/fluxcd/source-controller/blob/main/LICENSE)
 [![release](https://img.shields.io/github/release/fluxcd/source-controller/all.svg)](https://github.com/fluxcd/source-controller/releases)
 
+## About this fork
+
+This fork is used by the
+[qdrant-cloud-agent](https://github.com/qdrant/qdrant-cloud-agent/). The main
+reason behind forking the upstream project is to be able to distribute the CRDs of this
+project without risk of collision in case the customer is using Flux CD in their
+K8s cluster. The main change between the fork and upstream consist of renaming the
+API group names, replacing the ones from fluxcd (ex: `source.toolkit.fluxcd.io`)
+by our custom ones.
+
+### Maintaining the fork up to date
+
+- Configure and fetch upstream/main.
+- Create your development branch from origin/main and merge upstream/main into
+  it. You can run the merge with `-X theirs` option.
+- Solve the git conflicts if any.
+- As there might be new files or content added in upstream, we might need to
+  rename groups again. You can do that executing
+  `./scripts/rename-api-groups.sh`.
+- Run `go mod tidy` to clean up the dependencies and execute the tests of the project with `make test`.
+- Ideally, they are passing. Otherwise, you need to work on fixing any possible
+  issue.
+- Push your development branch. After that, you would need to test it using it
+  in the cloud-agent to confirm everything works as expected.
+- Once you confirm it works fine, create a PR for review.
+- **Note for the reviewer:** The merge commit from upstream/main doesn't make
+  sense to review it. Focus on the commits with the changes relevant for the
+  project.
+
+---
+
 The source-controller is a Kubernetes operator, specialised in artifacts acquisition
 from external sources such as Git, OCI, Helm repositories and S3-compatible buckets.
 The source-controller implements the

--- a/adapter/adapter.go
+++ b/adapter/adapter.go
@@ -1,0 +1,237 @@
+package adapter
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"time"
+
+	helper "github.com/fluxcd/pkg/runtime/controller"
+	"github.com/fluxcd/pkg/runtime/events"
+	"github.com/fluxcd/source-controller/internal/helm/registry"
+
+	"context"
+
+	"github.com/fluxcd/source-controller/api/v1beta2"
+	"github.com/fluxcd/source-controller/internal/cache"
+	"github.com/fluxcd/source-controller/internal/controller"
+	intdigest "github.com/fluxcd/source-controller/internal/digest"
+	"helm.sh/helm/v3/pkg/getter"
+	v1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/ratelimiter"
+)
+
+var (
+	scheme   = runtime.NewScheme()
+	setupLog = ctrl.Log.WithName("setup")
+	getters  = getter.Providers{
+		getter.Provider{
+			Schemes: []string{"http", "https"},
+			New:     getter.NewHTTPGetter,
+		},
+		getter.Provider{
+			Schemes: []string{"oci"},
+			New:     getter.NewOCIGetter,
+		},
+	}
+)
+
+func init() {
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(v1beta2.AddToScheme(scheme))
+	utilruntime.Must(v1.AddToScheme(scheme))
+}
+
+type SourceAdapter struct {
+	Context           context.Context
+	StoragePath       string
+	FileServerPort    int
+	ControllerName    string
+	ReconcilerOptions ReconcilerOptions
+	MetricOptions     helper.Metrics
+	LeaderElection    *bool
+}
+type ReconcilerOptions struct {
+	RateLimiter               ratelimiter.RateLimiter
+	DependencyRequeueInterval time.Duration
+}
+
+func SetupSourceReconcilers(mgr ctrl.Manager, adapter SourceAdapter) error {
+	storage := mustInitStorage(
+		adapter.StoragePath,
+		adapter.getFileServerAddress(),
+		60*time.Second,
+		2,
+		intdigest.Canonical.String(),
+	)
+	cacheRecorder := cache.MustMakeMetrics()
+
+	helmIndexCache, helmIndexCacheItemTTL := mustInitHelmCache(0, "15m", "1m")
+	eventRecorder, err := events.NewRecorder(mgr, ctrl.Log, "", adapter.ControllerName)
+	if err != nil {
+		return err
+	}
+
+	if err := (&controller.HelmRepositoryReconciler{
+		Client:         mgr.GetClient(),
+		EventRecorder:  eventRecorder,
+		Metrics:        adapter.MetricOptions,
+		Storage:        storage,
+		Getters:        getters,
+		ControllerName: adapter.ControllerName,
+		Cache:          helmIndexCache,
+		TTL:            helmIndexCacheItemTTL,
+		CacheRecorder:  cacheRecorder,
+		LeaderElection: adapter.LeaderElection,
+	}).SetupWithManagerAndOptions(mgr, controller.HelmRepositoryReconcilerOptions{
+		RateLimiter: adapter.ReconcilerOptions.RateLimiter,
+	}); err != nil {
+		return err
+	}
+
+	if err := (&controller.GitRepositoryReconciler{
+		Client:         mgr.GetClient(),
+		EventRecorder:  eventRecorder,
+		Metrics:        adapter.MetricOptions,
+		Storage:        storage,
+		ControllerName: adapter.ControllerName,
+		LeaderElection: adapter.LeaderElection,
+	}).SetupWithManagerAndOptions(mgr, controller.GitRepositoryReconcilerOptions{
+		DependencyRequeueInterval: adapter.ReconcilerOptions.DependencyRequeueInterval,
+		RateLimiter:               adapter.ReconcilerOptions.RateLimiter,
+	}); err != nil {
+		return err
+	}
+
+	if err := (&controller.BucketReconciler{
+		Client:         mgr.GetClient(),
+		EventRecorder:  eventRecorder,
+		Metrics:        adapter.MetricOptions,
+		Storage:        storage,
+		ControllerName: adapter.ControllerName,
+		LeaderElection: adapter.LeaderElection,
+	}).SetupWithManagerAndOptions(mgr, controller.BucketReconcilerOptions{
+		RateLimiter: adapter.ReconcilerOptions.RateLimiter,
+	}); err != nil {
+		return err
+	}
+
+	if err := (&controller.HelmChartReconciler{
+		Client:                  mgr.GetClient(),
+		RegistryClientGenerator: registry.ClientGenerator,
+		Storage:                 storage,
+		Getters:                 getters,
+		EventRecorder:           eventRecorder,
+		Metrics:                 adapter.MetricOptions,
+		ControllerName:          adapter.ControllerName,
+		Cache:                   helmIndexCache,
+		TTL:                     helmIndexCacheItemTTL,
+		CacheRecorder:           cacheRecorder,
+		LeaderElection:          adapter.LeaderElection,
+	}).SetupWithManagerAndOptions(adapter.Context, mgr, controller.HelmChartReconcilerOptions{
+		RateLimiter: adapter.ReconcilerOptions.RateLimiter,
+	}); err != nil {
+		return err
+	}
+
+	// Start file server for serving chart archives
+	go func() {
+		// Block until our controller manager is elected leader. We presume our
+		// entire process will terminate if we lose leadership, so we don't need
+		// to handle that.
+		<-mgr.Elected()
+
+		startFileServer(storage.BasePath, adapter.getFileServerAddress())
+	}()
+	return nil
+}
+
+func (a *SourceAdapter) getFileServerAddress() string {
+	port := 9090
+	if a.FileServerPort != 0 {
+		port = a.FileServerPort
+	}
+	return fmt.Sprintf(":%d", port)
+}
+
+func mustInitStorage(path string, storageAdvAddr string, artifactRetentionTTL time.Duration, artifactRetentionRecords int, artifactDigestAlgo string) *controller.Storage {
+	if storageAdvAddr == "" {
+		storageAdvAddr = determineAdvStorageAddr(storageAdvAddr)
+	}
+
+	if artifactDigestAlgo != intdigest.Canonical.String() {
+		algo, err := intdigest.AlgorithmForName(artifactDigestAlgo)
+		if err != nil {
+			setupLog.Error(err, "unable to configure canonical digest algorithm")
+			os.Exit(1)
+		}
+		intdigest.Canonical = algo
+	}
+
+	storage, err := controller.NewStorage(path, storageAdvAddr, artifactRetentionTTL, artifactRetentionRecords)
+	if err != nil {
+		setupLog.Error(err, "unable to initialise storage")
+		os.Exit(1)
+	}
+	return storage
+}
+
+func mustInitHelmCache(maxSize int, itemTTL, purgeInterval string) (*cache.Cache, time.Duration) {
+	if maxSize <= 0 {
+		setupLog.Info("caching of Helm index files is disabled")
+		return nil, -1
+	}
+
+	interval, err := time.ParseDuration(purgeInterval)
+	if err != nil {
+		setupLog.Error(err, "unable to parse Helm index cache purge interval")
+		os.Exit(1)
+	}
+
+	ttl, err := time.ParseDuration(itemTTL)
+	if err != nil {
+		setupLog.Error(err, "unable to parse Helm index cache item TTL")
+		os.Exit(1)
+	}
+
+	return cache.New(maxSize, interval), ttl
+}
+
+func determineAdvStorageAddr(storageAddr string) string {
+	host, port, err := net.SplitHostPort(storageAddr)
+	if err != nil {
+		setupLog.Error(err, "unable to parse storage address")
+		os.Exit(1)
+	}
+	switch host {
+	case "":
+		host = "localhost"
+	case "0.0.0.0":
+		host = os.Getenv("HOSTNAME")
+		if host == "" {
+			hn, err := os.Hostname()
+			if err != nil {
+				setupLog.Error(err, "0.0.0.0 specified in storage addr but hostname is invalid")
+				os.Exit(1)
+			}
+			host = hn
+		}
+	}
+	return net.JoinHostPort(host, port)
+}
+
+func startFileServer(path string, address string) {
+	setupLog.Info("starting file server")
+	fs := http.FileServer(http.Dir(path))
+	mux := http.NewServeMux()
+	mux.Handle("/", fs)
+	err := http.ListenAndServe(address, mux)
+	if err != nil {
+		setupLog.Error(err, "file server error")
+	}
+}

--- a/adapter/adapter.go
+++ b/adapter/adapter.go
@@ -22,8 +22,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/ratelimiter"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 var (
@@ -57,7 +58,7 @@ type SourceAdapter struct {
 	LeaderElection    *bool
 }
 type ReconcilerOptions struct {
-	RateLimiter               ratelimiter.RateLimiter
+	RateLimiter               workqueue.TypedRateLimiter[reconcile.Request]
 	DependencyRequeueInterval time.Duration
 }
 

--- a/api/v1/condition_types.go
+++ b/api/v1/condition_types.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package v1
 
-const SourceFinalizer = "finalizers.fluxcd.io"
+const SourceFinalizer = "finalizers.qdrant.io"
 
 const (
 	// ArtifactInStorageCondition indicates the availability of the Artifact in

--- a/api/v1/doc.go
+++ b/api/v1/doc.go
@@ -16,5 +16,5 @@ limitations under the License.
 
 // Package v1 contains API Schema definitions for the source v1 API group
 // +kubebuilder:object:generate=true
-// +groupName=source.toolkit.fluxcd.io
+// +groupName=cd.qdrant.io
 package v1

--- a/api/v1/gitrepository_types.go
+++ b/api/v1/gitrepository_types.go
@@ -311,7 +311,7 @@ func (v *GitRepositoryVerification) VerifyTag() bool {
 // +genclient
 // +kubebuilder:storageversion
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:shortName=gitrepo
+// +kubebuilder:resource:shortName=qdrantgitrepo
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="URL",type=string,JSONPath=`.spec.url`
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description=""

--- a/api/v1/groupversion_info.go
+++ b/api/v1/groupversion_info.go
@@ -23,7 +23,7 @@ import (
 
 var (
 	// GroupVersion is group version used to register these objects.
-	GroupVersion = schema.GroupVersion{Group: "source.toolkit.fluxcd.io", Version: "v1"}
+	GroupVersion = schema.GroupVersion{Group: "cd.qdrant.io", Version: "v1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/api/v1/helmchart_types.go
+++ b/api/v1/helmchart_types.go
@@ -194,7 +194,7 @@ func (in *HelmChart) GetValuesFiles() []string {
 // +genclient
 // +kubebuilder:storageversion
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:shortName=hc
+// +kubebuilder:resource:shortName=qdranthc
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Chart",type=string,JSONPath=`.spec.chart`
 // +kubebuilder:printcolumn:name="Version",type=string,JSONPath=`.spec.version`

--- a/api/v1/helmrepository_types.go
+++ b/api/v1/helmrepository_types.go
@@ -198,7 +198,7 @@ func (in *HelmRepository) GetArtifact() *Artifact {
 // +genclient
 // +kubebuilder:storageversion
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:shortName=helmrepo
+// +kubebuilder:resource:shortName=qdranthelmrepo
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="URL",type=string,JSONPath=`.spec.url`
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description=""

--- a/api/v1/source.go
+++ b/api/v1/source.go
@@ -30,7 +30,7 @@ const (
 
 // Source interface must be supported by all API types.
 // Source is the interface that provides generic access to the Artifact and
-// interval. It must be supported by all kinds of the source.toolkit.fluxcd.io
+// interval. It must be supported by all kinds of the cd.qdrant.io
 // API group.
 //
 // +k8s:deepcopy-gen=false

--- a/api/v1beta1/condition_types.go
+++ b/api/v1beta1/condition_types.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package v1beta1
 
-const SourceFinalizer = "finalizers.fluxcd.io"
+const SourceFinalizer = "finalizers.qdrant.io"
 
 const (
 	// URLInvalidReason represents the fact that a given source has an invalid URL.

--- a/api/v1beta1/doc.go
+++ b/api/v1beta1/doc.go
@@ -16,5 +16,5 @@ limitations under the License.
 
 // Package v1beta1 contains API Schema definitions for the source v1beta1 API group
 // +kubebuilder:object:generate=true
-// +groupName=source.toolkit.fluxcd.io
+// +groupName=cd.qdrant.io
 package v1beta1

--- a/api/v1beta1/gitrepository_types.go
+++ b/api/v1beta1/gitrepository_types.go
@@ -266,7 +266,7 @@ func (in *GitRepository) GetInterval() metav1.Duration {
 
 // +genclient
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:shortName=gitrepo
+// +kubebuilder:resource:shortName=qdrantgitrepo
 // +kubebuilder:subresource:status
 // +kubebuilder:deprecatedversion:warning="v1beta1 GitRepository is deprecated, upgrade to v1"
 // +kubebuilder:printcolumn:name="URL",type=string,JSONPath=`.spec.url`

--- a/api/v1beta1/groupversion_info.go
+++ b/api/v1beta1/groupversion_info.go
@@ -23,7 +23,7 @@ import (
 
 var (
 	// GroupVersion is group version used to register these objects.
-	GroupVersion = schema.GroupVersion{Group: "source.toolkit.fluxcd.io", Version: "v1beta1"}
+	GroupVersion = schema.GroupVersion{Group: "cd.qdrant.io", Version: "v1beta1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/api/v1beta1/helmchart_types.go
+++ b/api/v1beta1/helmchart_types.go
@@ -232,7 +232,7 @@ func (in *HelmChart) GetValuesFiles() []string {
 
 // +genclient
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:shortName=hc
+// +kubebuilder:resource:shortName=qdranthc
 // +kubebuilder:subresource:status
 // +kubebuilder:deprecatedversion:warning="v1beta1 HelmChart is deprecated, upgrade to v1"
 // +kubebuilder:printcolumn:name="Chart",type=string,JSONPath=`.spec.chart`

--- a/api/v1beta1/helmrepository_types.go
+++ b/api/v1beta1/helmrepository_types.go
@@ -182,7 +182,7 @@ func (in *HelmRepository) GetInterval() metav1.Duration {
 
 // +genclient
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:shortName=helmrepo
+// +kubebuilder:resource:shortName=qdranthelmrepo
 // +kubebuilder:subresource:status
 // +kubebuilder:deprecatedversion:warning="v1beta1 HelmRepository is deprecated, upgrade to v1"
 // +kubebuilder:printcolumn:name="URL",type=string,JSONPath=`.spec.url`

--- a/api/v1beta2/condition_types.go
+++ b/api/v1beta2/condition_types.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package v1beta2
 
-const SourceFinalizer = "finalizers.fluxcd.io"
+const SourceFinalizer = "finalizers.qdrant.io"
 
 const (
 	// ArtifactInStorageCondition indicates the availability of the Artifact in

--- a/api/v1beta2/doc.go
+++ b/api/v1beta2/doc.go
@@ -16,5 +16,5 @@ limitations under the License.
 
 // Package v1beta2 contains API Schema definitions for the source v1beta2 API group
 // +kubebuilder:object:generate=true
-// +groupName=source.toolkit.fluxcd.io
+// +groupName=cd.qdrant.io
 package v1beta2

--- a/api/v1beta2/gitrepository_types.go
+++ b/api/v1beta2/gitrepository_types.go
@@ -288,7 +288,7 @@ func (in *GitRepository) GetArtifact() *apiv1.Artifact {
 
 // +genclient
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:shortName=gitrepo
+// +kubebuilder:resource:shortName=qdrantgitrepo
 // +kubebuilder:subresource:status
 // +kubebuilder:deprecatedversion:warning="v1beta2 GitRepository is deprecated, upgrade to v1"
 // +kubebuilder:printcolumn:name="URL",type=string,JSONPath=`.spec.url`

--- a/api/v1beta2/groupversion_info.go
+++ b/api/v1beta2/groupversion_info.go
@@ -23,7 +23,7 @@ import (
 
 var (
 	// GroupVersion is group version used to register these objects.
-	GroupVersion = schema.GroupVersion{Group: "source.toolkit.fluxcd.io", Version: "v1beta2"}
+	GroupVersion = schema.GroupVersion{Group: "cd.qdrant.io", Version: "v1beta2"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/api/v1beta2/helmchart_types.go
+++ b/api/v1beta2/helmchart_types.go
@@ -216,7 +216,7 @@ func (in *HelmChart) GetValuesFiles() []string {
 
 // +genclient
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:shortName=hc
+// +kubebuilder:resource:shortName=qdranthc
 // +kubebuilder:subresource:status
 // +kubebuilder:deprecatedversion:warning="v1beta2 HelmChart is deprecated, upgrade to v1"
 // +kubebuilder:printcolumn:name="Chart",type=string,JSONPath=`.spec.chart`

--- a/api/v1beta2/helmrepository_types.go
+++ b/api/v1beta2/helmrepository_types.go
@@ -199,7 +199,7 @@ func (in *HelmRepository) GetArtifact() *apiv1.Artifact {
 
 // +genclient
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:shortName=helmrepo
+// +kubebuilder:resource:shortName=qdranthelmrepo
 // +kubebuilder:subresource:status
 // +kubebuilder:deprecatedversion:warning="v1beta2 HelmRepository is deprecated, upgrade to v1"
 // +kubebuilder:printcolumn:name="URL",type=string,JSONPath=`.spec.url`

--- a/api/v1beta2/ocirepository_types.go
+++ b/api/v1beta2/ocirepository_types.go
@@ -285,7 +285,7 @@ func (in *OCIRepository) GetLayerOperation() string {
 // +genclient
 // +kubebuilder:storageversion
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:shortName=ocirepo
+// +kubebuilder:resource:shortName=qdrantocirepo
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="URL",type=string,JSONPath=`.spec.url`
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].status",description=""

--- a/api/v1beta2/source.go
+++ b/api/v1beta2/source.go
@@ -30,7 +30,7 @@ const (
 
 // Source interface must be supported by all API types.
 // Source is the interface that provides generic access to the Artifact and
-// interval. It must be supported by all kinds of the source.toolkit.fluxcd.io
+// interval. It must be supported by all kinds of the cd.qdrant.io
 // API group.
 //
 // Deprecated: use the Source interface from api/v1 instead. This type will be

--- a/config/crd/bases/cd.qdrant.io_buckets.yaml
+++ b/config/crd/bases/cd.qdrant.io_buckets.yaml
@@ -1,0 +1,613 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  name: buckets.cd.qdrant.io
+spec:
+  group: cd.qdrant.io
+  names:
+    kind: Bucket
+    listKind: BucketList
+    plural: buckets
+    singular: bucket
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.endpoint
+      name: Endpoint
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    deprecated: true
+    deprecationWarning: v1beta1 Bucket is deprecated, upgrade to v1beta2
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Bucket is the Schema for the buckets API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BucketSpec defines the desired state of an S3 compatible
+              bucket
+            properties:
+              accessFrom:
+                description: AccessFrom defines an Access Control List for allowing
+                  cross-namespace references to this object.
+                properties:
+                  namespaceSelectors:
+                    description: |-
+                      NamespaceSelectors is the list of namespace selectors to which this ACL applies.
+                      Items in this list are evaluated using a logical OR operation.
+                    items:
+                      description: |-
+                        NamespaceSelector selects the namespaces to which this ACL applies.
+                        An empty map of MatchLabels matches all namespaces in a cluster.
+                      properties:
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                    type: array
+                required:
+                - namespaceSelectors
+                type: object
+              bucketName:
+                description: The bucket name.
+                type: string
+              endpoint:
+                description: The bucket endpoint address.
+                type: string
+              ignore:
+                description: |-
+                  Ignore overrides the set of excluded patterns in the .sourceignore format
+                  (which is the same as .gitignore). If not provided, a default will be used,
+                  consult the documentation for your version to find out what those are.
+                type: string
+              insecure:
+                description: Insecure allows connecting to a non-TLS S3 HTTP endpoint.
+                type: boolean
+              interval:
+                description: The interval at which to check for bucket updates.
+                type: string
+              provider:
+                default: generic
+                description: The S3 compatible storage provider name, default ('generic').
+                enum:
+                - generic
+                - aws
+                - gcp
+                type: string
+              region:
+                description: The bucket region.
+                type: string
+              secretRef:
+                description: |-
+                  The name of the secret containing authentication credentials
+                  for the Bucket.
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              suspend:
+                description: This flag tells the controller to suspend the reconciliation
+                  of this source.
+                type: boolean
+              timeout:
+                default: 60s
+                description: The timeout for download operations, defaults to 60s.
+                type: string
+            required:
+            - bucketName
+            - endpoint
+            - interval
+            type: object
+          status:
+            default:
+              observedGeneration: -1
+            description: BucketStatus defines the observed state of a bucket
+            properties:
+              artifact:
+                description: Artifact represents the output of the last successful
+                  Bucket sync.
+                properties:
+                  checksum:
+                    description: Checksum is the SHA256 checksum of the artifact.
+                    type: string
+                  lastUpdateTime:
+                    description: |-
+                      LastUpdateTime is the timestamp corresponding to the last update of this
+                      artifact.
+                    format: date-time
+                    type: string
+                  path:
+                    description: Path is the relative file path of this artifact.
+                    type: string
+                  revision:
+                    description: |-
+                      Revision is a human readable identifier traceable in the origin source
+                      system. It can be a Git commit SHA, Git tag, a Helm index timestamp, a Helm
+                      chart version, etc.
+                    type: string
+                  url:
+                    description: URL is the HTTP address of this artifact.
+                    type: string
+                required:
+                - path
+                - url
+                type: object
+              conditions:
+                description: Conditions holds the conditions for the Bucket.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastHandledReconcileAt:
+                description: |-
+                  LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value
+                  can be detected.
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the last observed generation.
+                format: int64
+                type: integer
+              url:
+                description: URL is the download link for the artifact output of the
+                  last Bucket sync.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.endpoint
+      name: Endpoint
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: Bucket is the Schema for the buckets API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              BucketSpec specifies the required configuration to produce an Artifact for
+              an object storage bucket.
+            properties:
+              accessFrom:
+                description: |-
+                  AccessFrom specifies an Access Control List for allowing cross-namespace
+                  references to this object.
+                  NOTE: Not implemented, provisional as of https://github.com/fluxcd/flux2/pull/2092
+                properties:
+                  namespaceSelectors:
+                    description: |-
+                      NamespaceSelectors is the list of namespace selectors to which this ACL applies.
+                      Items in this list are evaluated using a logical OR operation.
+                    items:
+                      description: |-
+                        NamespaceSelector selects the namespaces to which this ACL applies.
+                        An empty map of MatchLabels matches all namespaces in a cluster.
+                      properties:
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                    type: array
+                required:
+                - namespaceSelectors
+                type: object
+              bucketName:
+                description: BucketName is the name of the object storage bucket.
+                type: string
+              certSecretRef:
+                description: |-
+                  CertSecretRef can be given the name of a Secret containing
+                  either or both of
+
+
+                  - a PEM-encoded client certificate (`tls.crt`) and private
+                  key (`tls.key`);
+                  - a PEM-encoded CA certificate (`ca.crt`)
+
+
+                  and whichever are supplied, will be used for connecting to the
+                  bucket. The client cert and key are useful if you are
+                  authenticating with a certificate; the CA cert is useful if
+                  you are using a self-signed server certificate. The Secret must
+                  be of type `Opaque` or `kubernetes.io/tls`.
+
+
+                  This field is only supported for the `generic` provider.
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              endpoint:
+                description: Endpoint is the object storage address the BucketName
+                  is located at.
+                type: string
+              ignore:
+                description: |-
+                  Ignore overrides the set of excluded patterns in the .sourceignore format
+                  (which is the same as .gitignore). If not provided, a default will be used,
+                  consult the documentation for your version to find out what those are.
+                type: string
+              insecure:
+                description: Insecure allows connecting to a non-TLS HTTP Endpoint.
+                type: boolean
+              interval:
+                description: |-
+                  Interval at which the Bucket Endpoint is checked for updates.
+                  This interval is approximate and may be subject to jitter to ensure
+                  efficient use of resources.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                type: string
+              prefix:
+                description: Prefix to use for server-side filtering of files in the
+                  Bucket.
+                type: string
+              provider:
+                default: generic
+                description: |-
+                  Provider of the object storage bucket.
+                  Defaults to 'generic', which expects an S3 (API) compatible object
+                  storage.
+                enum:
+                - generic
+                - aws
+                - gcp
+                - azure
+                type: string
+              proxySecretRef:
+                description: |-
+                  ProxySecretRef specifies the Secret containing the proxy configuration
+                  to use while communicating with the Bucket server.
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              region:
+                description: Region of the Endpoint where the BucketName is located
+                  in.
+                type: string
+              secretRef:
+                description: |-
+                  SecretRef specifies the Secret containing authentication credentials
+                  for the Bucket.
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              sts:
+                description: |-
+                  STS specifies the required configuration to use a Security Token
+                  Service for fetching temporary credentials to authenticate in a
+                  Bucket provider.
+
+
+                  This field is only supported for the `aws` provider.
+                properties:
+                  endpoint:
+                    description: |-
+                      Endpoint is the HTTP/S endpoint of the Security Token Service from
+                      where temporary credentials will be fetched.
+                    pattern: ^(http|https)://.*$
+                    type: string
+                  provider:
+                    description: Provider of the Security Token Service.
+                    enum:
+                    - aws
+                    type: string
+                required:
+                - endpoint
+                - provider
+                type: object
+              suspend:
+                description: |-
+                  Suspend tells the controller to suspend the reconciliation of this
+                  Bucket.
+                type: boolean
+              timeout:
+                default: 60s
+                description: Timeout for fetch operations, defaults to 60s.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+                type: string
+            required:
+            - bucketName
+            - endpoint
+            - interval
+            type: object
+            x-kubernetes-validations:
+            - message: STS configuration is only supported for the 'aws' Bucket provider
+              rule: self.provider == 'aws' || !has(self.sts)
+            - message: '''aws'' is the only supported STS provider for the ''aws''
+                Bucket provider'
+              rule: self.provider != 'aws' || !has(self.sts) || self.sts.provider
+                == 'aws'
+          status:
+            default:
+              observedGeneration: -1
+            description: BucketStatus records the observed state of a Bucket.
+            properties:
+              artifact:
+                description: Artifact represents the last successful Bucket reconciliation.
+                properties:
+                  digest:
+                    description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
+                    pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
+                    type: string
+                  lastUpdateTime:
+                    description: |-
+                      LastUpdateTime is the timestamp corresponding to the last update of the
+                      Artifact.
+                    format: date-time
+                    type: string
+                  metadata:
+                    additionalProperties:
+                      type: string
+                    description: Metadata holds upstream information such as OCI annotations.
+                    type: object
+                  path:
+                    description: |-
+                      Path is the relative file path of the Artifact. It can be used to locate
+                      the file in the root of the Artifact storage on the local file system of
+                      the controller managing the Source.
+                    type: string
+                  revision:
+                    description: |-
+                      Revision is a human-readable identifier traceable in the origin source
+                      system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
+                    type: string
+                  size:
+                    description: Size is the number of bytes in the file.
+                    format: int64
+                    type: integer
+                  url:
+                    description: |-
+                      URL is the HTTP address of the Artifact as exposed by the controller
+                      managing the Source. It can be used to retrieve the Artifact for
+                      consumption, e.g. by another controller applying the Artifact contents.
+                    type: string
+                required:
+                - lastUpdateTime
+                - path
+                - revision
+                - url
+                type: object
+              conditions:
+                description: Conditions holds the conditions for the Bucket.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastHandledReconcileAt:
+                description: |-
+                  LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value
+                  can be detected.
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the last observed generation of
+                  the Bucket object.
+                format: int64
+                type: integer
+              observedIgnore:
+                description: |-
+                  ObservedIgnore is the observed exclusion patterns used for constructing
+                  the source artifact.
+                type: string
+              url:
+                description: |-
+                  URL is the dynamic fetch link for the latest Artifact.
+                  It is provided on a "best effort" basis, and using the precise
+                  BucketStatus.Artifact data is recommended.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/crd/bases/cd.qdrant.io_gitrepositories.yaml
+++ b/config/crd/bases/cd.qdrant.io_gitrepositories.yaml
@@ -1,0 +1,1292 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  name: gitrepositories.cd.qdrant.io
+spec:
+  group: cd.qdrant.io
+  names:
+    kind: GitRepository
+    listKind: GitRepositoryList
+    plural: gitrepositories
+    shortNames:
+    - qdrantgitrepo
+    singular: gitrepository
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.url
+      name: URL
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: GitRepository is the Schema for the gitrepositories API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              GitRepositorySpec specifies the required configuration to produce an
+              Artifact for a Git repository.
+            properties:
+              ignore:
+                description: |-
+                  Ignore overrides the set of excluded patterns in the .sourceignore format
+                  (which is the same as .gitignore). If not provided, a default will be used,
+                  consult the documentation for your version to find out what those are.
+                type: string
+              include:
+                description: |-
+                  Include specifies a list of GitRepository resources which Artifacts
+                  should be included in the Artifact produced for this GitRepository.
+                items:
+                  description: |-
+                    GitRepositoryInclude specifies a local reference to a GitRepository which
+                    Artifact (sub-)contents must be included, and where they should be placed.
+                  properties:
+                    fromPath:
+                      description: |-
+                        FromPath specifies the path to copy contents from, defaults to the root
+                        of the Artifact.
+                      type: string
+                    repository:
+                      description: |-
+                        GitRepositoryRef specifies the GitRepository which Artifact contents
+                        must be included.
+                      properties:
+                        name:
+                          description: Name of the referent.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    toPath:
+                      description: |-
+                        ToPath specifies the path to copy contents to, defaults to the name of
+                        the GitRepositoryRef.
+                      type: string
+                  required:
+                  - repository
+                  type: object
+                type: array
+              interval:
+                description: |-
+                  Interval at which the GitRepository URL is checked for updates.
+                  This interval is approximate and may be subject to jitter to ensure
+                  efficient use of resources.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                type: string
+              proxySecretRef:
+                description: |-
+                  ProxySecretRef specifies the Secret containing the proxy configuration
+                  to use while communicating with the Git server.
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              recurseSubmodules:
+                description: |-
+                  RecurseSubmodules enables the initialization of all submodules within
+                  the GitRepository as cloned from the URL, using their default settings.
+                type: boolean
+              ref:
+                description: |-
+                  Reference specifies the Git reference to resolve and monitor for
+                  changes, defaults to the 'master' branch.
+                properties:
+                  branch:
+                    description: Branch to check out, defaults to 'master' if no other
+                      field is defined.
+                    type: string
+                  commit:
+                    description: |-
+                      Commit SHA to check out, takes precedence over all reference fields.
+
+
+                      This can be combined with Branch to shallow clone the branch, in which
+                      the commit is expected to exist.
+                    type: string
+                  name:
+                    description: |-
+                      Name of the reference to check out; takes precedence over Branch, Tag and SemVer.
+
+
+                      It must be a valid Git reference: https://git-scm.com/docs/git-check-ref-format#_description
+                      Examples: "refs/heads/main", "refs/tags/v0.1.0", "refs/pull/420/head", "refs/merge-requests/1/head"
+                    type: string
+                  semver:
+                    description: SemVer tag expression to check out, takes precedence
+                      over Tag.
+                    type: string
+                  tag:
+                    description: Tag to check out, takes precedence over Branch.
+                    type: string
+                type: object
+              secretRef:
+                description: |-
+                  SecretRef specifies the Secret containing authentication credentials for
+                  the GitRepository.
+                  For HTTPS repositories the Secret must contain 'username' and 'password'
+                  fields for basic auth or 'bearerToken' field for token auth.
+                  For SSH repositories the Secret must contain 'identity'
+                  and 'known_hosts' fields.
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              suspend:
+                description: |-
+                  Suspend tells the controller to suspend the reconciliation of this
+                  GitRepository.
+                type: boolean
+              timeout:
+                default: 60s
+                description: Timeout for Git operations like cloning, defaults to
+                  60s.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+                type: string
+              url:
+                description: URL specifies the Git repository URL, it can be an HTTP/S
+                  or SSH address.
+                pattern: ^(http|https|ssh)://.*$
+                type: string
+              verify:
+                description: |-
+                  Verification specifies the configuration to verify the Git commit
+                  signature(s).
+                properties:
+                  mode:
+                    default: HEAD
+                    description: |-
+                      Mode specifies which Git object(s) should be verified.
+
+
+                      The variants "head" and "HEAD" both imply the same thing, i.e. verify
+                      the commit that the HEAD of the Git repository points to. The variant
+                      "head" solely exists to ensure backwards compatibility.
+                    enum:
+                    - head
+                    - HEAD
+                    - Tag
+                    - TagAndHEAD
+                    type: string
+                  secretRef:
+                    description: |-
+                      SecretRef specifies the Secret containing the public keys of trusted Git
+                      authors.
+                    properties:
+                      name:
+                        description: Name of the referent.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                required:
+                - secretRef
+                type: object
+            required:
+            - interval
+            - url
+            type: object
+          status:
+            default:
+              observedGeneration: -1
+            description: GitRepositoryStatus records the observed state of a Git repository.
+            properties:
+              artifact:
+                description: Artifact represents the last successful GitRepository
+                  reconciliation.
+                properties:
+                  digest:
+                    description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
+                    pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
+                    type: string
+                  lastUpdateTime:
+                    description: |-
+                      LastUpdateTime is the timestamp corresponding to the last update of the
+                      Artifact.
+                    format: date-time
+                    type: string
+                  metadata:
+                    additionalProperties:
+                      type: string
+                    description: Metadata holds upstream information such as OCI annotations.
+                    type: object
+                  path:
+                    description: |-
+                      Path is the relative file path of the Artifact. It can be used to locate
+                      the file in the root of the Artifact storage on the local file system of
+                      the controller managing the Source.
+                    type: string
+                  revision:
+                    description: |-
+                      Revision is a human-readable identifier traceable in the origin source
+                      system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
+                    type: string
+                  size:
+                    description: Size is the number of bytes in the file.
+                    format: int64
+                    type: integer
+                  url:
+                    description: |-
+                      URL is the HTTP address of the Artifact as exposed by the controller
+                      managing the Source. It can be used to retrieve the Artifact for
+                      consumption, e.g. by another controller applying the Artifact contents.
+                    type: string
+                required:
+                - lastUpdateTime
+                - path
+                - revision
+                - url
+                type: object
+              conditions:
+                description: Conditions holds the conditions for the GitRepository.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              includedArtifacts:
+                description: |-
+                  IncludedArtifacts contains a list of the last successfully included
+                  Artifacts as instructed by GitRepositorySpec.Include.
+                items:
+                  description: Artifact represents the output of a Source reconciliation.
+                  properties:
+                    digest:
+                      description: Digest is the digest of the file in the form of
+                        '<algorithm>:<checksum>'.
+                      pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
+                      type: string
+                    lastUpdateTime:
+                      description: |-
+                        LastUpdateTime is the timestamp corresponding to the last update of the
+                        Artifact.
+                      format: date-time
+                      type: string
+                    metadata:
+                      additionalProperties:
+                        type: string
+                      description: Metadata holds upstream information such as OCI
+                        annotations.
+                      type: object
+                    path:
+                      description: |-
+                        Path is the relative file path of the Artifact. It can be used to locate
+                        the file in the root of the Artifact storage on the local file system of
+                        the controller managing the Source.
+                      type: string
+                    revision:
+                      description: |-
+                        Revision is a human-readable identifier traceable in the origin source
+                        system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
+                      type: string
+                    size:
+                      description: Size is the number of bytes in the file.
+                      format: int64
+                      type: integer
+                    url:
+                      description: |-
+                        URL is the HTTP address of the Artifact as exposed by the controller
+                        managing the Source. It can be used to retrieve the Artifact for
+                        consumption, e.g. by another controller applying the Artifact contents.
+                      type: string
+                  required:
+                  - lastUpdateTime
+                  - path
+                  - revision
+                  - url
+                  type: object
+                type: array
+              lastHandledReconcileAt:
+                description: |-
+                  LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value
+                  can be detected.
+                type: string
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the last observed generation of the GitRepository
+                  object.
+                format: int64
+                type: integer
+              observedIgnore:
+                description: |-
+                  ObservedIgnore is the observed exclusion patterns used for constructing
+                  the source artifact.
+                type: string
+              observedInclude:
+                description: |-
+                  ObservedInclude is the observed list of GitRepository resources used to
+                  produce the current Artifact.
+                items:
+                  description: |-
+                    GitRepositoryInclude specifies a local reference to a GitRepository which
+                    Artifact (sub-)contents must be included, and where they should be placed.
+                  properties:
+                    fromPath:
+                      description: |-
+                        FromPath specifies the path to copy contents from, defaults to the root
+                        of the Artifact.
+                      type: string
+                    repository:
+                      description: |-
+                        GitRepositoryRef specifies the GitRepository which Artifact contents
+                        must be included.
+                      properties:
+                        name:
+                          description: Name of the referent.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    toPath:
+                      description: |-
+                        ToPath specifies the path to copy contents to, defaults to the name of
+                        the GitRepositoryRef.
+                      type: string
+                  required:
+                  - repository
+                  type: object
+                type: array
+              observedRecurseSubmodules:
+                description: |-
+                  ObservedRecurseSubmodules is the observed resource submodules
+                  configuration used to produce the current Artifact.
+                type: boolean
+              sourceVerificationMode:
+                description: |-
+                  SourceVerificationMode is the last used verification mode indicating
+                  which Git object(s) have been verified.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.url
+      name: URL
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    deprecated: true
+    deprecationWarning: v1beta1 GitRepository is deprecated, upgrade to v1
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: GitRepository is the Schema for the gitrepositories API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: GitRepositorySpec defines the desired state of a Git repository.
+            properties:
+              accessFrom:
+                description: AccessFrom defines an Access Control List for allowing
+                  cross-namespace references to this object.
+                properties:
+                  namespaceSelectors:
+                    description: |-
+                      NamespaceSelectors is the list of namespace selectors to which this ACL applies.
+                      Items in this list are evaluated using a logical OR operation.
+                    items:
+                      description: |-
+                        NamespaceSelector selects the namespaces to which this ACL applies.
+                        An empty map of MatchLabels matches all namespaces in a cluster.
+                      properties:
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                    type: array
+                required:
+                - namespaceSelectors
+                type: object
+              gitImplementation:
+                default: go-git
+                description: |-
+                  Determines which git client library to use.
+                  Defaults to go-git, valid values are ('go-git', 'libgit2').
+                enum:
+                - go-git
+                - libgit2
+                type: string
+              ignore:
+                description: |-
+                  Ignore overrides the set of excluded patterns in the .sourceignore format
+                  (which is the same as .gitignore). If not provided, a default will be used,
+                  consult the documentation for your version to find out what those are.
+                type: string
+              include:
+                description: Extra git repositories to map into the repository
+                items:
+                  description: GitRepositoryInclude defines a source with a from and
+                    to path.
+                  properties:
+                    fromPath:
+                      description: The path to copy contents from, defaults to the
+                        root directory.
+                      type: string
+                    repository:
+                      description: Reference to a GitRepository to include.
+                      properties:
+                        name:
+                          description: Name of the referent.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    toPath:
+                      description: The path to copy contents to, defaults to the name
+                        of the source ref.
+                      type: string
+                  required:
+                  - repository
+                  type: object
+                type: array
+              interval:
+                description: The interval at which to check for repository updates.
+                type: string
+              recurseSubmodules:
+                description: |-
+                  When enabled, after the clone is created, initializes all submodules within,
+                  using their default settings.
+                  This option is available only when using the 'go-git' GitImplementation.
+                type: boolean
+              ref:
+                description: |-
+                  The Git reference to checkout and monitor for changes, defaults to
+                  master branch.
+                properties:
+                  branch:
+                    description: The Git branch to checkout, defaults to master.
+                    type: string
+                  commit:
+                    description: The Git commit SHA to checkout, if specified Tag
+                      filters will be ignored.
+                    type: string
+                  semver:
+                    description: The Git tag semver expression, takes precedence over
+                      Tag.
+                    type: string
+                  tag:
+                    description: The Git tag to checkout, takes precedence over Branch.
+                    type: string
+                type: object
+              secretRef:
+                description: |-
+                  The secret name containing the Git credentials.
+                  For HTTPS repositories the secret must contain username and password
+                  fields.
+                  For SSH repositories the secret must contain identity and known_hosts
+                  fields.
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              suspend:
+                description: This flag tells the controller to suspend the reconciliation
+                  of this source.
+                type: boolean
+              timeout:
+                default: 60s
+                description: The timeout for remote Git operations like cloning, defaults
+                  to 60s.
+                type: string
+              url:
+                description: The repository URL, can be a HTTP/S or SSH address.
+                pattern: ^(http|https|ssh)://.*$
+                type: string
+              verify:
+                description: Verify OpenPGP signature for the Git commit HEAD points
+                  to.
+                properties:
+                  mode:
+                    description: Mode describes what git object should be verified,
+                      currently ('head').
+                    enum:
+                    - head
+                    type: string
+                  secretRef:
+                    description: The secret name containing the public keys of all
+                      trusted Git authors.
+                    properties:
+                      name:
+                        description: Name of the referent.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                required:
+                - mode
+                type: object
+            required:
+            - interval
+            - url
+            type: object
+          status:
+            default:
+              observedGeneration: -1
+            description: GitRepositoryStatus defines the observed state of a Git repository.
+            properties:
+              artifact:
+                description: Artifact represents the output of the last successful
+                  repository sync.
+                properties:
+                  checksum:
+                    description: Checksum is the SHA256 checksum of the artifact.
+                    type: string
+                  lastUpdateTime:
+                    description: |-
+                      LastUpdateTime is the timestamp corresponding to the last update of this
+                      artifact.
+                    format: date-time
+                    type: string
+                  path:
+                    description: Path is the relative file path of this artifact.
+                    type: string
+                  revision:
+                    description: |-
+                      Revision is a human readable identifier traceable in the origin source
+                      system. It can be a Git commit SHA, Git tag, a Helm index timestamp, a Helm
+                      chart version, etc.
+                    type: string
+                  url:
+                    description: URL is the HTTP address of this artifact.
+                    type: string
+                required:
+                - path
+                - url
+                type: object
+              conditions:
+                description: Conditions holds the conditions for the GitRepository.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              includedArtifacts:
+                description: IncludedArtifacts represents the included artifacts from
+                  the last successful repository sync.
+                items:
+                  description: Artifact represents the output of a source synchronisation.
+                  properties:
+                    checksum:
+                      description: Checksum is the SHA256 checksum of the artifact.
+                      type: string
+                    lastUpdateTime:
+                      description: |-
+                        LastUpdateTime is the timestamp corresponding to the last update of this
+                        artifact.
+                      format: date-time
+                      type: string
+                    path:
+                      description: Path is the relative file path of this artifact.
+                      type: string
+                    revision:
+                      description: |-
+                        Revision is a human readable identifier traceable in the origin source
+                        system. It can be a Git commit SHA, Git tag, a Helm index timestamp, a Helm
+                        chart version, etc.
+                      type: string
+                    url:
+                      description: URL is the HTTP address of this artifact.
+                      type: string
+                  required:
+                  - path
+                  - url
+                  type: object
+                type: array
+              lastHandledReconcileAt:
+                description: |-
+                  LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value
+                  can be detected.
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the last observed generation.
+                format: int64
+                type: integer
+              url:
+                description: |-
+                  URL is the download link for the artifact output of the last repository
+                  sync.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.url
+      name: URL
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    deprecated: true
+    deprecationWarning: v1beta2 GitRepository is deprecated, upgrade to v1
+    name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: GitRepository is the Schema for the gitrepositories API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              GitRepositorySpec specifies the required configuration to produce an
+              Artifact for a Git repository.
+            properties:
+              accessFrom:
+                description: |-
+                  AccessFrom specifies an Access Control List for allowing cross-namespace
+                  references to this object.
+                  NOTE: Not implemented, provisional as of https://github.com/fluxcd/flux2/pull/2092
+                properties:
+                  namespaceSelectors:
+                    description: |-
+                      NamespaceSelectors is the list of namespace selectors to which this ACL applies.
+                      Items in this list are evaluated using a logical OR operation.
+                    items:
+                      description: |-
+                        NamespaceSelector selects the namespaces to which this ACL applies.
+                        An empty map of MatchLabels matches all namespaces in a cluster.
+                      properties:
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                    type: array
+                required:
+                - namespaceSelectors
+                type: object
+              gitImplementation:
+                default: go-git
+                description: |-
+                  GitImplementation specifies which Git client library implementation to
+                  use. Defaults to 'go-git', valid values are ('go-git', 'libgit2').
+                  Deprecated: gitImplementation is deprecated now that 'go-git' is the
+                  only supported implementation.
+                enum:
+                - go-git
+                - libgit2
+                type: string
+              ignore:
+                description: |-
+                  Ignore overrides the set of excluded patterns in the .sourceignore format
+                  (which is the same as .gitignore). If not provided, a default will be used,
+                  consult the documentation for your version to find out what those are.
+                type: string
+              include:
+                description: |-
+                  Include specifies a list of GitRepository resources which Artifacts
+                  should be included in the Artifact produced for this GitRepository.
+                items:
+                  description: |-
+                    GitRepositoryInclude specifies a local reference to a GitRepository which
+                    Artifact (sub-)contents must be included, and where they should be placed.
+                  properties:
+                    fromPath:
+                      description: |-
+                        FromPath specifies the path to copy contents from, defaults to the root
+                        of the Artifact.
+                      type: string
+                    repository:
+                      description: |-
+                        GitRepositoryRef specifies the GitRepository which Artifact contents
+                        must be included.
+                      properties:
+                        name:
+                          description: Name of the referent.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    toPath:
+                      description: |-
+                        ToPath specifies the path to copy contents to, defaults to the name of
+                        the GitRepositoryRef.
+                      type: string
+                  required:
+                  - repository
+                  type: object
+                type: array
+              interval:
+                description: Interval at which to check the GitRepository for updates.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                type: string
+              recurseSubmodules:
+                description: |-
+                  RecurseSubmodules enables the initialization of all submodules within
+                  the GitRepository as cloned from the URL, using their default settings.
+                type: boolean
+              ref:
+                description: |-
+                  Reference specifies the Git reference to resolve and monitor for
+                  changes, defaults to the 'master' branch.
+                properties:
+                  branch:
+                    description: Branch to check out, defaults to 'master' if no other
+                      field is defined.
+                    type: string
+                  commit:
+                    description: |-
+                      Commit SHA to check out, takes precedence over all reference fields.
+
+
+                      This can be combined with Branch to shallow clone the branch, in which
+                      the commit is expected to exist.
+                    type: string
+                  name:
+                    description: |-
+                      Name of the reference to check out; takes precedence over Branch, Tag and SemVer.
+
+
+                      It must be a valid Git reference: https://git-scm.com/docs/git-check-ref-format#_description
+                      Examples: "refs/heads/main", "refs/tags/v0.1.0", "refs/pull/420/head", "refs/merge-requests/1/head"
+                    type: string
+                  semver:
+                    description: SemVer tag expression to check out, takes precedence
+                      over Tag.
+                    type: string
+                  tag:
+                    description: Tag to check out, takes precedence over Branch.
+                    type: string
+                type: object
+              secretRef:
+                description: |-
+                  SecretRef specifies the Secret containing authentication credentials for
+                  the GitRepository.
+                  For HTTPS repositories the Secret must contain 'username' and 'password'
+                  fields for basic auth or 'bearerToken' field for token auth.
+                  For SSH repositories the Secret must contain 'identity'
+                  and 'known_hosts' fields.
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              suspend:
+                description: |-
+                  Suspend tells the controller to suspend the reconciliation of this
+                  GitRepository.
+                type: boolean
+              timeout:
+                default: 60s
+                description: Timeout for Git operations like cloning, defaults to
+                  60s.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+                type: string
+              url:
+                description: URL specifies the Git repository URL, it can be an HTTP/S
+                  or SSH address.
+                pattern: ^(http|https|ssh)://.*$
+                type: string
+              verify:
+                description: |-
+                  Verification specifies the configuration to verify the Git commit
+                  signature(s).
+                properties:
+                  mode:
+                    description: Mode specifies what Git object should be verified,
+                      currently ('head').
+                    enum:
+                    - head
+                    type: string
+                  secretRef:
+                    description: |-
+                      SecretRef specifies the Secret containing the public keys of trusted Git
+                      authors.
+                    properties:
+                      name:
+                        description: Name of the referent.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                required:
+                - mode
+                - secretRef
+                type: object
+            required:
+            - interval
+            - url
+            type: object
+          status:
+            default:
+              observedGeneration: -1
+            description: GitRepositoryStatus records the observed state of a Git repository.
+            properties:
+              artifact:
+                description: Artifact represents the last successful GitRepository
+                  reconciliation.
+                properties:
+                  digest:
+                    description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
+                    pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
+                    type: string
+                  lastUpdateTime:
+                    description: |-
+                      LastUpdateTime is the timestamp corresponding to the last update of the
+                      Artifact.
+                    format: date-time
+                    type: string
+                  metadata:
+                    additionalProperties:
+                      type: string
+                    description: Metadata holds upstream information such as OCI annotations.
+                    type: object
+                  path:
+                    description: |-
+                      Path is the relative file path of the Artifact. It can be used to locate
+                      the file in the root of the Artifact storage on the local file system of
+                      the controller managing the Source.
+                    type: string
+                  revision:
+                    description: |-
+                      Revision is a human-readable identifier traceable in the origin source
+                      system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
+                    type: string
+                  size:
+                    description: Size is the number of bytes in the file.
+                    format: int64
+                    type: integer
+                  url:
+                    description: |-
+                      URL is the HTTP address of the Artifact as exposed by the controller
+                      managing the Source. It can be used to retrieve the Artifact for
+                      consumption, e.g. by another controller applying the Artifact contents.
+                    type: string
+                required:
+                - lastUpdateTime
+                - path
+                - revision
+                - url
+                type: object
+              conditions:
+                description: Conditions holds the conditions for the GitRepository.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              contentConfigChecksum:
+                description: |-
+                  ContentConfigChecksum is a checksum of all the configurations related to
+                  the content of the source artifact:
+                   - .spec.ignore
+                   - .spec.recurseSubmodules
+                   - .spec.included and the checksum of the included artifacts
+                  observed in .status.observedGeneration version of the object. This can
+                  be used to determine if the content of the included repository has
+                  changed.
+                  It has the format of `<algo>:<checksum>`, for example: `sha256:<checksum>`.
+
+
+                  Deprecated: Replaced with explicit fields for observed artifact content
+                  config in the status.
+                type: string
+              includedArtifacts:
+                description: |-
+                  IncludedArtifacts contains a list of the last successfully included
+                  Artifacts as instructed by GitRepositorySpec.Include.
+                items:
+                  description: Artifact represents the output of a Source reconciliation.
+                  properties:
+                    digest:
+                      description: Digest is the digest of the file in the form of
+                        '<algorithm>:<checksum>'.
+                      pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
+                      type: string
+                    lastUpdateTime:
+                      description: |-
+                        LastUpdateTime is the timestamp corresponding to the last update of the
+                        Artifact.
+                      format: date-time
+                      type: string
+                    metadata:
+                      additionalProperties:
+                        type: string
+                      description: Metadata holds upstream information such as OCI
+                        annotations.
+                      type: object
+                    path:
+                      description: |-
+                        Path is the relative file path of the Artifact. It can be used to locate
+                        the file in the root of the Artifact storage on the local file system of
+                        the controller managing the Source.
+                      type: string
+                    revision:
+                      description: |-
+                        Revision is a human-readable identifier traceable in the origin source
+                        system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
+                      type: string
+                    size:
+                      description: Size is the number of bytes in the file.
+                      format: int64
+                      type: integer
+                    url:
+                      description: |-
+                        URL is the HTTP address of the Artifact as exposed by the controller
+                        managing the Source. It can be used to retrieve the Artifact for
+                        consumption, e.g. by another controller applying the Artifact contents.
+                      type: string
+                  required:
+                  - lastUpdateTime
+                  - path
+                  - revision
+                  - url
+                  type: object
+                type: array
+              lastHandledReconcileAt:
+                description: |-
+                  LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value
+                  can be detected.
+                type: string
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the last observed generation of the GitRepository
+                  object.
+                format: int64
+                type: integer
+              observedIgnore:
+                description: |-
+                  ObservedIgnore is the observed exclusion patterns used for constructing
+                  the source artifact.
+                type: string
+              observedInclude:
+                description: |-
+                  ObservedInclude is the observed list of GitRepository resources used to
+                  to produce the current Artifact.
+                items:
+                  description: |-
+                    GitRepositoryInclude specifies a local reference to a GitRepository which
+                    Artifact (sub-)contents must be included, and where they should be placed.
+                  properties:
+                    fromPath:
+                      description: |-
+                        FromPath specifies the path to copy contents from, defaults to the root
+                        of the Artifact.
+                      type: string
+                    repository:
+                      description: |-
+                        GitRepositoryRef specifies the GitRepository which Artifact contents
+                        must be included.
+                      properties:
+                        name:
+                          description: Name of the referent.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    toPath:
+                      description: |-
+                        ToPath specifies the path to copy contents to, defaults to the name of
+                        the GitRepositoryRef.
+                      type: string
+                  required:
+                  - repository
+                  type: object
+                type: array
+              observedRecurseSubmodules:
+                description: |-
+                  ObservedRecurseSubmodules is the observed resource submodules
+                  configuration used to produce the current Artifact.
+                type: boolean
+              url:
+                description: |-
+                  URL is the dynamic fetch link for the latest Artifact.
+                  It is provided on a "best effort" basis, and using the precise
+                  GitRepositoryStatus.Artifact data is recommended.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}

--- a/config/crd/bases/cd.qdrant.io_helmcharts.yaml
+++ b/config/crd/bases/cd.qdrant.io_helmcharts.yaml
@@ -1,0 +1,1014 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  name: helmcharts.cd.qdrant.io
+spec:
+  group: cd.qdrant.io
+  names:
+    kind: HelmChart
+    listKind: HelmChartList
+    plural: helmcharts
+    shortNames:
+    - qdranthc
+    singular: helmchart
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.chart
+      name: Chart
+      type: string
+    - jsonPath: .spec.version
+      name: Version
+      type: string
+    - jsonPath: .spec.sourceRef.kind
+      name: Source Kind
+      type: string
+    - jsonPath: .spec.sourceRef.name
+      name: Source Name
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: HelmChart is the Schema for the helmcharts API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: HelmChartSpec specifies the desired state of a Helm chart.
+            properties:
+              chart:
+                description: |-
+                  Chart is the name or path the Helm chart is available at in the
+                  SourceRef.
+                type: string
+              ignoreMissingValuesFiles:
+                description: |-
+                  IgnoreMissingValuesFiles controls whether to silently ignore missing values
+                  files rather than failing.
+                type: boolean
+              interval:
+                description: |-
+                  Interval at which the HelmChart SourceRef is checked for updates.
+                  This interval is approximate and may be subject to jitter to ensure
+                  efficient use of resources.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                type: string
+              reconcileStrategy:
+                default: ChartVersion
+                description: |-
+                  ReconcileStrategy determines what enables the creation of a new artifact.
+                  Valid values are ('ChartVersion', 'Revision').
+                  See the documentation of the values for an explanation on their behavior.
+                  Defaults to ChartVersion when omitted.
+                enum:
+                - ChartVersion
+                - Revision
+                type: string
+              sourceRef:
+                description: SourceRef is the reference to the Source the chart is
+                  available at.
+                properties:
+                  apiVersion:
+                    description: APIVersion of the referent.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent, valid values are ('HelmRepository', 'GitRepository',
+                      'Bucket').
+                    enum:
+                    - HelmRepository
+                    - GitRepository
+                    - Bucket
+                    type: string
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              suspend:
+                description: |-
+                  Suspend tells the controller to suspend the reconciliation of this
+                  source.
+                type: boolean
+              valuesFiles:
+                description: |-
+                  ValuesFiles is an alternative list of values files to use as the chart
+                  values (values.yaml is not included by default), expected to be a
+                  relative path in the SourceRef.
+                  Values files are merged in the order of this list with the last file
+                  overriding the first. Ignored when omitted.
+                items:
+                  type: string
+                type: array
+              verify:
+                description: |-
+                  Verify contains the secret name containing the trusted public keys
+                  used to verify the signature and specifies which provider to use to check
+                  whether OCI image is authentic.
+                  This field is only supported when using HelmRepository source with spec.type 'oci'.
+                  Chart dependencies, which are not bundled in the umbrella chart artifact, are not verified.
+                properties:
+                  matchOIDCIdentity:
+                    description: |-
+                      MatchOIDCIdentity specifies the identity matching criteria to use
+                      while verifying an OCI artifact which was signed using Cosign keyless
+                      signing. The artifact's identity is deemed to be verified if any of the
+                      specified matchers match against the identity.
+                    items:
+                      description: |-
+                        OIDCIdentityMatch specifies options for verifying the certificate identity,
+                        i.e. the issuer and the subject of the certificate.
+                      properties:
+                        issuer:
+                          description: |-
+                            Issuer specifies the regex pattern to match against to verify
+                            the OIDC issuer in the Fulcio certificate. The pattern must be a
+                            valid Go regular expression.
+                          type: string
+                        subject:
+                          description: |-
+                            Subject specifies the regex pattern to match against to verify
+                            the identity subject in the Fulcio certificate. The pattern must
+                            be a valid Go regular expression.
+                          type: string
+                      required:
+                      - issuer
+                      - subject
+                      type: object
+                    type: array
+                  provider:
+                    default: cosign
+                    description: Provider specifies the technology used to sign the
+                      OCI Artifact.
+                    enum:
+                    - cosign
+                    - notation
+                    type: string
+                  secretRef:
+                    description: |-
+                      SecretRef specifies the Kubernetes Secret containing the
+                      trusted public keys.
+                    properties:
+                      name:
+                        description: Name of the referent.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                required:
+                - provider
+                type: object
+              version:
+                default: '*'
+                description: |-
+                  Version is the chart version semver expression, ignored for charts from
+                  GitRepository and Bucket sources. Defaults to latest when omitted.
+                type: string
+            required:
+            - chart
+            - interval
+            - sourceRef
+            type: object
+          status:
+            default:
+              observedGeneration: -1
+            description: HelmChartStatus records the observed state of the HelmChart.
+            properties:
+              artifact:
+                description: Artifact represents the output of the last successful
+                  reconciliation.
+                properties:
+                  digest:
+                    description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
+                    pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
+                    type: string
+                  lastUpdateTime:
+                    description: |-
+                      LastUpdateTime is the timestamp corresponding to the last update of the
+                      Artifact.
+                    format: date-time
+                    type: string
+                  metadata:
+                    additionalProperties:
+                      type: string
+                    description: Metadata holds upstream information such as OCI annotations.
+                    type: object
+                  path:
+                    description: |-
+                      Path is the relative file path of the Artifact. It can be used to locate
+                      the file in the root of the Artifact storage on the local file system of
+                      the controller managing the Source.
+                    type: string
+                  revision:
+                    description: |-
+                      Revision is a human-readable identifier traceable in the origin source
+                      system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
+                    type: string
+                  size:
+                    description: Size is the number of bytes in the file.
+                    format: int64
+                    type: integer
+                  url:
+                    description: |-
+                      URL is the HTTP address of the Artifact as exposed by the controller
+                      managing the Source. It can be used to retrieve the Artifact for
+                      consumption, e.g. by another controller applying the Artifact contents.
+                    type: string
+                required:
+                - lastUpdateTime
+                - path
+                - revision
+                - url
+                type: object
+              conditions:
+                description: Conditions holds the conditions for the HelmChart.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastHandledReconcileAt:
+                description: |-
+                  LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value
+                  can be detected.
+                type: string
+              observedChartName:
+                description: |-
+                  ObservedChartName is the last observed chart name as specified by the
+                  resolved chart reference.
+                type: string
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the last observed generation of the HelmChart
+                  object.
+                format: int64
+                type: integer
+              observedSourceArtifactRevision:
+                description: |-
+                  ObservedSourceArtifactRevision is the last observed Artifact.Revision
+                  of the HelmChartSpec.SourceRef.
+                type: string
+              observedValuesFiles:
+                description: |-
+                  ObservedValuesFiles are the observed value files of the last successful
+                  reconciliation.
+                  It matches the chart in the last successfully reconciled artifact.
+                items:
+                  type: string
+                type: array
+              url:
+                description: |-
+                  URL is the dynamic fetch link for the latest Artifact.
+                  It is provided on a "best effort" basis, and using the precise
+                  BucketStatus.Artifact data is recommended.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.chart
+      name: Chart
+      type: string
+    - jsonPath: .spec.version
+      name: Version
+      type: string
+    - jsonPath: .spec.sourceRef.kind
+      name: Source Kind
+      type: string
+    - jsonPath: .spec.sourceRef.name
+      name: Source Name
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    deprecated: true
+    deprecationWarning: v1beta1 HelmChart is deprecated, upgrade to v1
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: HelmChart is the Schema for the helmcharts API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: HelmChartSpec defines the desired state of a Helm chart.
+            properties:
+              accessFrom:
+                description: AccessFrom defines an Access Control List for allowing
+                  cross-namespace references to this object.
+                properties:
+                  namespaceSelectors:
+                    description: |-
+                      NamespaceSelectors is the list of namespace selectors to which this ACL applies.
+                      Items in this list are evaluated using a logical OR operation.
+                    items:
+                      description: |-
+                        NamespaceSelector selects the namespaces to which this ACL applies.
+                        An empty map of MatchLabels matches all namespaces in a cluster.
+                      properties:
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                    type: array
+                required:
+                - namespaceSelectors
+                type: object
+              chart:
+                description: The name or path the Helm chart is available at in the
+                  SourceRef.
+                type: string
+              interval:
+                description: The interval at which to check the Source for updates.
+                type: string
+              reconcileStrategy:
+                default: ChartVersion
+                description: |-
+                  Determines what enables the creation of a new artifact. Valid values are
+                  ('ChartVersion', 'Revision').
+                  See the documentation of the values for an explanation on their behavior.
+                  Defaults to ChartVersion when omitted.
+                enum:
+                - ChartVersion
+                - Revision
+                type: string
+              sourceRef:
+                description: The reference to the Source the chart is available at.
+                properties:
+                  apiVersion:
+                    description: APIVersion of the referent.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent, valid values are ('HelmRepository', 'GitRepository',
+                      'Bucket').
+                    enum:
+                    - HelmRepository
+                    - GitRepository
+                    - Bucket
+                    type: string
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              suspend:
+                description: This flag tells the controller to suspend the reconciliation
+                  of this source.
+                type: boolean
+              valuesFile:
+                description: |-
+                  Alternative values file to use as the default chart values, expected to
+                  be a relative path in the SourceRef. Deprecated in favor of ValuesFiles,
+                  for backwards compatibility the file defined here is merged before the
+                  ValuesFiles items. Ignored when omitted.
+                type: string
+              valuesFiles:
+                description: |-
+                  Alternative list of values files to use as the chart values (values.yaml
+                  is not included by default), expected to be a relative path in the SourceRef.
+                  Values files are merged in the order of this list with the last file overriding
+                  the first. Ignored when omitted.
+                items:
+                  type: string
+                type: array
+              version:
+                default: '*'
+                description: |-
+                  The chart version semver expression, ignored for charts from GitRepository
+                  and Bucket sources. Defaults to latest when omitted.
+                type: string
+            required:
+            - chart
+            - interval
+            - sourceRef
+            type: object
+          status:
+            default:
+              observedGeneration: -1
+            description: HelmChartStatus defines the observed state of the HelmChart.
+            properties:
+              artifact:
+                description: Artifact represents the output of the last successful
+                  chart sync.
+                properties:
+                  checksum:
+                    description: Checksum is the SHA256 checksum of the artifact.
+                    type: string
+                  lastUpdateTime:
+                    description: |-
+                      LastUpdateTime is the timestamp corresponding to the last update of this
+                      artifact.
+                    format: date-time
+                    type: string
+                  path:
+                    description: Path is the relative file path of this artifact.
+                    type: string
+                  revision:
+                    description: |-
+                      Revision is a human readable identifier traceable in the origin source
+                      system. It can be a Git commit SHA, Git tag, a Helm index timestamp, a Helm
+                      chart version, etc.
+                    type: string
+                  url:
+                    description: URL is the HTTP address of this artifact.
+                    type: string
+                required:
+                - path
+                - url
+                type: object
+              conditions:
+                description: Conditions holds the conditions for the HelmChart.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastHandledReconcileAt:
+                description: |-
+                  LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value
+                  can be detected.
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the last observed generation.
+                format: int64
+                type: integer
+              url:
+                description: URL is the download link for the last chart pulled.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.chart
+      name: Chart
+      type: string
+    - jsonPath: .spec.version
+      name: Version
+      type: string
+    - jsonPath: .spec.sourceRef.kind
+      name: Source Kind
+      type: string
+    - jsonPath: .spec.sourceRef.name
+      name: Source Name
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    deprecated: true
+    deprecationWarning: v1beta2 HelmChart is deprecated, upgrade to v1
+    name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: HelmChart is the Schema for the helmcharts API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: HelmChartSpec specifies the desired state of a Helm chart.
+            properties:
+              accessFrom:
+                description: |-
+                  AccessFrom specifies an Access Control List for allowing cross-namespace
+                  references to this object.
+                  NOTE: Not implemented, provisional as of https://github.com/fluxcd/flux2/pull/2092
+                properties:
+                  namespaceSelectors:
+                    description: |-
+                      NamespaceSelectors is the list of namespace selectors to which this ACL applies.
+                      Items in this list are evaluated using a logical OR operation.
+                    items:
+                      description: |-
+                        NamespaceSelector selects the namespaces to which this ACL applies.
+                        An empty map of MatchLabels matches all namespaces in a cluster.
+                      properties:
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                    type: array
+                required:
+                - namespaceSelectors
+                type: object
+              chart:
+                description: |-
+                  Chart is the name or path the Helm chart is available at in the
+                  SourceRef.
+                type: string
+              ignoreMissingValuesFiles:
+                description: |-
+                  IgnoreMissingValuesFiles controls whether to silently ignore missing values
+                  files rather than failing.
+                type: boolean
+              interval:
+                description: |-
+                  Interval at which the HelmChart SourceRef is checked for updates.
+                  This interval is approximate and may be subject to jitter to ensure
+                  efficient use of resources.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                type: string
+              reconcileStrategy:
+                default: ChartVersion
+                description: |-
+                  ReconcileStrategy determines what enables the creation of a new artifact.
+                  Valid values are ('ChartVersion', 'Revision').
+                  See the documentation of the values for an explanation on their behavior.
+                  Defaults to ChartVersion when omitted.
+                enum:
+                - ChartVersion
+                - Revision
+                type: string
+              sourceRef:
+                description: SourceRef is the reference to the Source the chart is
+                  available at.
+                properties:
+                  apiVersion:
+                    description: APIVersion of the referent.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent, valid values are ('HelmRepository', 'GitRepository',
+                      'Bucket').
+                    enum:
+                    - HelmRepository
+                    - GitRepository
+                    - Bucket
+                    type: string
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              suspend:
+                description: |-
+                  Suspend tells the controller to suspend the reconciliation of this
+                  source.
+                type: boolean
+              valuesFile:
+                description: |-
+                  ValuesFile is an alternative values file to use as the default chart
+                  values, expected to be a relative path in the SourceRef. Deprecated in
+                  favor of ValuesFiles, for backwards compatibility the file specified here
+                  is merged before the ValuesFiles items. Ignored when omitted.
+                type: string
+              valuesFiles:
+                description: |-
+                  ValuesFiles is an alternative list of values files to use as the chart
+                  values (values.yaml is not included by default), expected to be a
+                  relative path in the SourceRef.
+                  Values files are merged in the order of this list with the last file
+                  overriding the first. Ignored when omitted.
+                items:
+                  type: string
+                type: array
+              verify:
+                description: |-
+                  Verify contains the secret name containing the trusted public keys
+                  used to verify the signature and specifies which provider to use to check
+                  whether OCI image is authentic.
+                  This field is only supported when using HelmRepository source with spec.type 'oci'.
+                  Chart dependencies, which are not bundled in the umbrella chart artifact, are not verified.
+                properties:
+                  matchOIDCIdentity:
+                    description: |-
+                      MatchOIDCIdentity specifies the identity matching criteria to use
+                      while verifying an OCI artifact which was signed using Cosign keyless
+                      signing. The artifact's identity is deemed to be verified if any of the
+                      specified matchers match against the identity.
+                    items:
+                      description: |-
+                        OIDCIdentityMatch specifies options for verifying the certificate identity,
+                        i.e. the issuer and the subject of the certificate.
+                      properties:
+                        issuer:
+                          description: |-
+                            Issuer specifies the regex pattern to match against to verify
+                            the OIDC issuer in the Fulcio certificate. The pattern must be a
+                            valid Go regular expression.
+                          type: string
+                        subject:
+                          description: |-
+                            Subject specifies the regex pattern to match against to verify
+                            the identity subject in the Fulcio certificate. The pattern must
+                            be a valid Go regular expression.
+                          type: string
+                      required:
+                      - issuer
+                      - subject
+                      type: object
+                    type: array
+                  provider:
+                    default: cosign
+                    description: Provider specifies the technology used to sign the
+                      OCI Artifact.
+                    enum:
+                    - cosign
+                    - notation
+                    type: string
+                  secretRef:
+                    description: |-
+                      SecretRef specifies the Kubernetes Secret containing the
+                      trusted public keys.
+                    properties:
+                      name:
+                        description: Name of the referent.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                required:
+                - provider
+                type: object
+              version:
+                default: '*'
+                description: |-
+                  Version is the chart version semver expression, ignored for charts from
+                  GitRepository and Bucket sources. Defaults to latest when omitted.
+                type: string
+            required:
+            - chart
+            - interval
+            - sourceRef
+            type: object
+          status:
+            default:
+              observedGeneration: -1
+            description: HelmChartStatus records the observed state of the HelmChart.
+            properties:
+              artifact:
+                description: Artifact represents the output of the last successful
+                  reconciliation.
+                properties:
+                  digest:
+                    description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
+                    pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
+                    type: string
+                  lastUpdateTime:
+                    description: |-
+                      LastUpdateTime is the timestamp corresponding to the last update of the
+                      Artifact.
+                    format: date-time
+                    type: string
+                  metadata:
+                    additionalProperties:
+                      type: string
+                    description: Metadata holds upstream information such as OCI annotations.
+                    type: object
+                  path:
+                    description: |-
+                      Path is the relative file path of the Artifact. It can be used to locate
+                      the file in the root of the Artifact storage on the local file system of
+                      the controller managing the Source.
+                    type: string
+                  revision:
+                    description: |-
+                      Revision is a human-readable identifier traceable in the origin source
+                      system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
+                    type: string
+                  size:
+                    description: Size is the number of bytes in the file.
+                    format: int64
+                    type: integer
+                  url:
+                    description: |-
+                      URL is the HTTP address of the Artifact as exposed by the controller
+                      managing the Source. It can be used to retrieve the Artifact for
+                      consumption, e.g. by another controller applying the Artifact contents.
+                    type: string
+                required:
+                - lastUpdateTime
+                - path
+                - revision
+                - url
+                type: object
+              conditions:
+                description: Conditions holds the conditions for the HelmChart.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastHandledReconcileAt:
+                description: |-
+                  LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value
+                  can be detected.
+                type: string
+              observedChartName:
+                description: |-
+                  ObservedChartName is the last observed chart name as specified by the
+                  resolved chart reference.
+                type: string
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the last observed generation of the HelmChart
+                  object.
+                format: int64
+                type: integer
+              observedSourceArtifactRevision:
+                description: |-
+                  ObservedSourceArtifactRevision is the last observed Artifact.Revision
+                  of the HelmChartSpec.SourceRef.
+                type: string
+              observedValuesFiles:
+                description: |-
+                  ObservedValuesFiles are the observed value files of the last successful
+                  reconciliation.
+                  It matches the chart in the last successfully reconciled artifact.
+                items:
+                  type: string
+                type: array
+              url:
+                description: |-
+                  URL is the dynamic fetch link for the latest Artifact.
+                  It is provided on a "best effort" basis, and using the precise
+                  BucketStatus.Artifact data is recommended.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}

--- a/config/crd/bases/cd.qdrant.io_helmrepositories.yaml
+++ b/config/crd/bases/cd.qdrant.io_helmrepositories.yaml
@@ -1,0 +1,888 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  name: helmrepositories.cd.qdrant.io
+spec:
+  group: cd.qdrant.io
+  names:
+    kind: HelmRepository
+    listKind: HelmRepositoryList
+    plural: helmrepositories
+    shortNames:
+    - qdranthelmrepo
+    singular: helmrepository
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.url
+      name: URL
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: HelmRepository is the Schema for the helmrepositories API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              HelmRepositorySpec specifies the required configuration to produce an
+              Artifact for a Helm repository index YAML.
+            properties:
+              accessFrom:
+                description: |-
+                  AccessFrom specifies an Access Control List for allowing cross-namespace
+                  references to this object.
+                  NOTE: Not implemented, provisional as of https://github.com/fluxcd/flux2/pull/2092
+                properties:
+                  namespaceSelectors:
+                    description: |-
+                      NamespaceSelectors is the list of namespace selectors to which this ACL applies.
+                      Items in this list are evaluated using a logical OR operation.
+                    items:
+                      description: |-
+                        NamespaceSelector selects the namespaces to which this ACL applies.
+                        An empty map of MatchLabels matches all namespaces in a cluster.
+                      properties:
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                    type: array
+                required:
+                - namespaceSelectors
+                type: object
+              certSecretRef:
+                description: |-
+                  CertSecretRef can be given the name of a Secret containing
+                  either or both of
+
+
+                  - a PEM-encoded client certificate (`tls.crt`) and private
+                  key (`tls.key`);
+                  - a PEM-encoded CA certificate (`ca.crt`)
+
+
+                  and whichever are supplied, will be used for connecting to the
+                  registry. The client cert and key are useful if you are
+                  authenticating with a certificate; the CA cert is useful if
+                  you are using a self-signed server certificate. The Secret must
+                  be of type `Opaque` or `kubernetes.io/tls`.
+
+
+                  It takes precedence over the values specified in the Secret referred
+                  to by `.spec.secretRef`.
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              insecure:
+                description: |-
+                  Insecure allows connecting to a non-TLS HTTP container registry.
+                  This field is only taken into account if the .spec.type field is set to 'oci'.
+                type: boolean
+              interval:
+                description: |-
+                  Interval at which the HelmRepository URL is checked for updates.
+                  This interval is approximate and may be subject to jitter to ensure
+                  efficient use of resources.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                type: string
+              passCredentials:
+                description: |-
+                  PassCredentials allows the credentials from the SecretRef to be passed
+                  on to a host that does not match the host as defined in URL.
+                  This may be required if the host of the advertised chart URLs in the
+                  index differ from the defined URL.
+                  Enabling this should be done with caution, as it can potentially result
+                  in credentials getting stolen in a MITM-attack.
+                type: boolean
+              provider:
+                default: generic
+                description: |-
+                  Provider used for authentication, can be 'aws', 'azure', 'gcp' or 'generic'.
+                  This field is optional, and only taken into account if the .spec.type field is set to 'oci'.
+                  When not specified, defaults to 'generic'.
+                enum:
+                - generic
+                - aws
+                - azure
+                - gcp
+                type: string
+              secretRef:
+                description: |-
+                  SecretRef specifies the Secret containing authentication credentials
+                  for the HelmRepository.
+                  For HTTP/S basic auth the secret must contain 'username' and 'password'
+                  fields.
+                  Support for TLS auth using the 'certFile' and 'keyFile', and/or 'caFile'
+                  keys is deprecated. Please use `.spec.certSecretRef` instead.
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              suspend:
+                description: |-
+                  Suspend tells the controller to suspend the reconciliation of this
+                  HelmRepository.
+                type: boolean
+              timeout:
+                description: |-
+                  Timeout is used for the index fetch operation for an HTTPS helm repository,
+                  and for remote OCI Repository operations like pulling for an OCI helm
+                  chart by the associated HelmChart.
+                  Its default value is 60s.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+                type: string
+              type:
+                description: |-
+                  Type of the HelmRepository.
+                  When this field is set to  "oci", the URL field value must be prefixed with "oci://".
+                enum:
+                - default
+                - oci
+                type: string
+              url:
+                description: |-
+                  URL of the Helm repository, a valid URL contains at least a protocol and
+                  host.
+                pattern: ^(http|https|oci)://.*$
+                type: string
+            required:
+            - url
+            type: object
+          status:
+            default:
+              observedGeneration: -1
+            description: HelmRepositoryStatus records the observed state of the HelmRepository.
+            properties:
+              artifact:
+                description: Artifact represents the last successful HelmRepository
+                  reconciliation.
+                properties:
+                  digest:
+                    description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
+                    pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
+                    type: string
+                  lastUpdateTime:
+                    description: |-
+                      LastUpdateTime is the timestamp corresponding to the last update of the
+                      Artifact.
+                    format: date-time
+                    type: string
+                  metadata:
+                    additionalProperties:
+                      type: string
+                    description: Metadata holds upstream information such as OCI annotations.
+                    type: object
+                  path:
+                    description: |-
+                      Path is the relative file path of the Artifact. It can be used to locate
+                      the file in the root of the Artifact storage on the local file system of
+                      the controller managing the Source.
+                    type: string
+                  revision:
+                    description: |-
+                      Revision is a human-readable identifier traceable in the origin source
+                      system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
+                    type: string
+                  size:
+                    description: Size is the number of bytes in the file.
+                    format: int64
+                    type: integer
+                  url:
+                    description: |-
+                      URL is the HTTP address of the Artifact as exposed by the controller
+                      managing the Source. It can be used to retrieve the Artifact for
+                      consumption, e.g. by another controller applying the Artifact contents.
+                    type: string
+                required:
+                - lastUpdateTime
+                - path
+                - revision
+                - url
+                type: object
+              conditions:
+                description: Conditions holds the conditions for the HelmRepository.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastHandledReconcileAt:
+                description: |-
+                  LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value
+                  can be detected.
+                type: string
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the last observed generation of the HelmRepository
+                  object.
+                format: int64
+                type: integer
+              url:
+                description: |-
+                  URL is the dynamic fetch link for the latest Artifact.
+                  It is provided on a "best effort" basis, and using the precise
+                  HelmRepositoryStatus.Artifact data is recommended.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.url
+      name: URL
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    deprecated: true
+    deprecationWarning: v1beta1 HelmRepository is deprecated, upgrade to v1
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: HelmRepository is the Schema for the helmrepositories API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: HelmRepositorySpec defines the reference to a Helm repository.
+            properties:
+              accessFrom:
+                description: AccessFrom defines an Access Control List for allowing
+                  cross-namespace references to this object.
+                properties:
+                  namespaceSelectors:
+                    description: |-
+                      NamespaceSelectors is the list of namespace selectors to which this ACL applies.
+                      Items in this list are evaluated using a logical OR operation.
+                    items:
+                      description: |-
+                        NamespaceSelector selects the namespaces to which this ACL applies.
+                        An empty map of MatchLabels matches all namespaces in a cluster.
+                      properties:
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                    type: array
+                required:
+                - namespaceSelectors
+                type: object
+              interval:
+                description: The interval at which to check the upstream for updates.
+                type: string
+              passCredentials:
+                description: |-
+                  PassCredentials allows the credentials from the SecretRef to be passed on to
+                  a host that does not match the host as defined in URL.
+                  This may be required if the host of the advertised chart URLs in the index
+                  differ from the defined URL.
+                  Enabling this should be done with caution, as it can potentially result in
+                  credentials getting stolen in a MITM-attack.
+                type: boolean
+              secretRef:
+                description: |-
+                  The name of the secret containing authentication credentials for the Helm
+                  repository.
+                  For HTTP/S basic auth the secret must contain username and
+                  password fields.
+                  For TLS the secret must contain a certFile and keyFile, and/or
+                  caFile fields.
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              suspend:
+                description: This flag tells the controller to suspend the reconciliation
+                  of this source.
+                type: boolean
+              timeout:
+                default: 60s
+                description: The timeout of index downloading, defaults to 60s.
+                type: string
+              url:
+                description: The Helm repository URL, a valid URL contains at least
+                  a protocol and host.
+                type: string
+            required:
+            - interval
+            - url
+            type: object
+          status:
+            default:
+              observedGeneration: -1
+            description: HelmRepositoryStatus defines the observed state of the HelmRepository.
+            properties:
+              artifact:
+                description: Artifact represents the output of the last successful
+                  repository sync.
+                properties:
+                  checksum:
+                    description: Checksum is the SHA256 checksum of the artifact.
+                    type: string
+                  lastUpdateTime:
+                    description: |-
+                      LastUpdateTime is the timestamp corresponding to the last update of this
+                      artifact.
+                    format: date-time
+                    type: string
+                  path:
+                    description: Path is the relative file path of this artifact.
+                    type: string
+                  revision:
+                    description: |-
+                      Revision is a human readable identifier traceable in the origin source
+                      system. It can be a Git commit SHA, Git tag, a Helm index timestamp, a Helm
+                      chart version, etc.
+                    type: string
+                  url:
+                    description: URL is the HTTP address of this artifact.
+                    type: string
+                required:
+                - path
+                - url
+                type: object
+              conditions:
+                description: Conditions holds the conditions for the HelmRepository.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastHandledReconcileAt:
+                description: |-
+                  LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value
+                  can be detected.
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the last observed generation.
+                format: int64
+                type: integer
+              url:
+                description: URL is the download link for the last index fetched.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.url
+      name: URL
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    deprecated: true
+    deprecationWarning: v1beta2 HelmRepository is deprecated, upgrade to v1
+    name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: HelmRepository is the Schema for the helmrepositories API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              HelmRepositorySpec specifies the required configuration to produce an
+              Artifact for a Helm repository index YAML.
+            properties:
+              accessFrom:
+                description: |-
+                  AccessFrom specifies an Access Control List for allowing cross-namespace
+                  references to this object.
+                  NOTE: Not implemented, provisional as of https://github.com/fluxcd/flux2/pull/2092
+                properties:
+                  namespaceSelectors:
+                    description: |-
+                      NamespaceSelectors is the list of namespace selectors to which this ACL applies.
+                      Items in this list are evaluated using a logical OR operation.
+                    items:
+                      description: |-
+                        NamespaceSelector selects the namespaces to which this ACL applies.
+                        An empty map of MatchLabels matches all namespaces in a cluster.
+                      properties:
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                    type: array
+                required:
+                - namespaceSelectors
+                type: object
+              certSecretRef:
+                description: |-
+                  CertSecretRef can be given the name of a Secret containing
+                  either or both of
+
+
+                  - a PEM-encoded client certificate (`tls.crt`) and private
+                  key (`tls.key`);
+                  - a PEM-encoded CA certificate (`ca.crt`)
+
+
+                  and whichever are supplied, will be used for connecting to the
+                  registry. The client cert and key are useful if you are
+                  authenticating with a certificate; the CA cert is useful if
+                  you are using a self-signed server certificate. The Secret must
+                  be of type `Opaque` or `kubernetes.io/tls`.
+
+
+                  It takes precedence over the values specified in the Secret referred
+                  to by `.spec.secretRef`.
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              insecure:
+                description: |-
+                  Insecure allows connecting to a non-TLS HTTP container registry.
+                  This field is only taken into account if the .spec.type field is set to 'oci'.
+                type: boolean
+              interval:
+                description: |-
+                  Interval at which the HelmRepository URL is checked for updates.
+                  This interval is approximate and may be subject to jitter to ensure
+                  efficient use of resources.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                type: string
+              passCredentials:
+                description: |-
+                  PassCredentials allows the credentials from the SecretRef to be passed
+                  on to a host that does not match the host as defined in URL.
+                  This may be required if the host of the advertised chart URLs in the
+                  index differ from the defined URL.
+                  Enabling this should be done with caution, as it can potentially result
+                  in credentials getting stolen in a MITM-attack.
+                type: boolean
+              provider:
+                default: generic
+                description: |-
+                  Provider used for authentication, can be 'aws', 'azure', 'gcp' or 'generic'.
+                  This field is optional, and only taken into account if the .spec.type field is set to 'oci'.
+                  When not specified, defaults to 'generic'.
+                enum:
+                - generic
+                - aws
+                - azure
+                - gcp
+                type: string
+              secretRef:
+                description: |-
+                  SecretRef specifies the Secret containing authentication credentials
+                  for the HelmRepository.
+                  For HTTP/S basic auth the secret must contain 'username' and 'password'
+                  fields.
+                  Support for TLS auth using the 'certFile' and 'keyFile', and/or 'caFile'
+                  keys is deprecated. Please use `.spec.certSecretRef` instead.
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              suspend:
+                description: |-
+                  Suspend tells the controller to suspend the reconciliation of this
+                  HelmRepository.
+                type: boolean
+              timeout:
+                description: |-
+                  Timeout is used for the index fetch operation for an HTTPS helm repository,
+                  and for remote OCI Repository operations like pulling for an OCI helm
+                  chart by the associated HelmChart.
+                  Its default value is 60s.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+                type: string
+              type:
+                description: |-
+                  Type of the HelmRepository.
+                  When this field is set to  "oci", the URL field value must be prefixed with "oci://".
+                enum:
+                - default
+                - oci
+                type: string
+              url:
+                description: |-
+                  URL of the Helm repository, a valid URL contains at least a protocol and
+                  host.
+                pattern: ^(http|https|oci)://.*$
+                type: string
+            required:
+            - url
+            type: object
+          status:
+            default:
+              observedGeneration: -1
+            description: HelmRepositoryStatus records the observed state of the HelmRepository.
+            properties:
+              artifact:
+                description: Artifact represents the last successful HelmRepository
+                  reconciliation.
+                properties:
+                  digest:
+                    description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
+                    pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
+                    type: string
+                  lastUpdateTime:
+                    description: |-
+                      LastUpdateTime is the timestamp corresponding to the last update of the
+                      Artifact.
+                    format: date-time
+                    type: string
+                  metadata:
+                    additionalProperties:
+                      type: string
+                    description: Metadata holds upstream information such as OCI annotations.
+                    type: object
+                  path:
+                    description: |-
+                      Path is the relative file path of the Artifact. It can be used to locate
+                      the file in the root of the Artifact storage on the local file system of
+                      the controller managing the Source.
+                    type: string
+                  revision:
+                    description: |-
+                      Revision is a human-readable identifier traceable in the origin source
+                      system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
+                    type: string
+                  size:
+                    description: Size is the number of bytes in the file.
+                    format: int64
+                    type: integer
+                  url:
+                    description: |-
+                      URL is the HTTP address of the Artifact as exposed by the controller
+                      managing the Source. It can be used to retrieve the Artifact for
+                      consumption, e.g. by another controller applying the Artifact contents.
+                    type: string
+                required:
+                - lastUpdateTime
+                - path
+                - revision
+                - url
+                type: object
+              conditions:
+                description: Conditions holds the conditions for the HelmRepository.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastHandledReconcileAt:
+                description: |-
+                  LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value
+                  can be detected.
+                type: string
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the last observed generation of the HelmRepository
+                  object.
+                format: int64
+                type: integer
+              url:
+                description: |-
+                  URL is the dynamic fetch link for the latest Artifact.
+                  It is provided on a "best effort" basis, and using the precise
+                  HelmRepositoryStatus.Artifact data is recommended.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}

--- a/config/crd/bases/cd.qdrant.io_ocirepositories.yaml
+++ b/config/crd/bases/cd.qdrant.io_ocirepositories.yaml
@@ -1,0 +1,444 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  name: ocirepositories.cd.qdrant.io
+spec:
+  group: cd.qdrant.io
+  names:
+    kind: OCIRepository
+    listKind: OCIRepositoryList
+    plural: ocirepositories
+    shortNames:
+    - qdrantocirepo
+    singular: ocirepository
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.url
+      name: URL
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: OCIRepository is the Schema for the ocirepositories API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OCIRepositorySpec defines the desired state of OCIRepository
+            properties:
+              certSecretRef:
+                description: |-
+                  CertSecretRef can be given the name of a Secret containing
+                  either or both of
+
+
+                  - a PEM-encoded client certificate (`tls.crt`) and private
+                  key (`tls.key`);
+                  - a PEM-encoded CA certificate (`ca.crt`)
+
+
+                  and whichever are supplied, will be used for connecting to the
+                  registry. The client cert and key are useful if you are
+                  authenticating with a certificate; the CA cert is useful if
+                  you are using a self-signed server certificate. The Secret must
+                  be of type `Opaque` or `kubernetes.io/tls`.
+
+
+                  Note: Support for the `caFile`, `certFile` and `keyFile` keys have
+                  been deprecated.
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              ignore:
+                description: |-
+                  Ignore overrides the set of excluded patterns in the .sourceignore format
+                  (which is the same as .gitignore). If not provided, a default will be used,
+                  consult the documentation for your version to find out what those are.
+                type: string
+              insecure:
+                description: Insecure allows connecting to a non-TLS HTTP container
+                  registry.
+                type: boolean
+              interval:
+                description: |-
+                  Interval at which the OCIRepository URL is checked for updates.
+                  This interval is approximate and may be subject to jitter to ensure
+                  efficient use of resources.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                type: string
+              layerSelector:
+                description: |-
+                  LayerSelector specifies which layer should be extracted from the OCI artifact.
+                  When not specified, the first layer found in the artifact is selected.
+                properties:
+                  mediaType:
+                    description: |-
+                      MediaType specifies the OCI media type of the layer
+                      which should be extracted from the OCI Artifact. The
+                      first layer matching this type is selected.
+                    type: string
+                  operation:
+                    description: |-
+                      Operation specifies how the selected layer should be processed.
+                      By default, the layer compressed content is extracted to storage.
+                      When the operation is set to 'copy', the layer compressed content
+                      is persisted to storage as it is.
+                    enum:
+                    - extract
+                    - copy
+                    type: string
+                type: object
+              provider:
+                default: generic
+                description: |-
+                  The provider used for authentication, can be 'aws', 'azure', 'gcp' or 'generic'.
+                  When not specified, defaults to 'generic'.
+                enum:
+                - generic
+                - aws
+                - azure
+                - gcp
+                type: string
+              proxySecretRef:
+                description: |-
+                  ProxySecretRef specifies the Secret containing the proxy configuration
+                  to use while communicating with the container registry.
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              ref:
+                description: |-
+                  The OCI reference to pull and monitor for changes,
+                  defaults to the latest tag.
+                properties:
+                  digest:
+                    description: |-
+                      Digest is the image digest to pull, takes precedence over SemVer.
+                      The value should be in the format 'sha256:<HASH>'.
+                    type: string
+                  semver:
+                    description: |-
+                      SemVer is the range of tags to pull selecting the latest within
+                      the range, takes precedence over Tag.
+                    type: string
+                  semverFilter:
+                    description: SemverFilter is a regex pattern to filter the tags
+                      within the SemVer range.
+                    type: string
+                  tag:
+                    description: Tag is the image tag to pull, defaults to latest.
+                    type: string
+                type: object
+              secretRef:
+                description: |-
+                  SecretRef contains the secret name containing the registry login
+                  credentials to resolve image metadata.
+                  The secret must be of type kubernetes.io/dockerconfigjson.
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              serviceAccountName:
+                description: |-
+                  ServiceAccountName is the name of the Kubernetes ServiceAccount used to authenticate
+                  the image pull if the service account has attached pull secrets. For more information:
+                  https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account
+                type: string
+              suspend:
+                description: This flag tells the controller to suspend the reconciliation
+                  of this source.
+                type: boolean
+              timeout:
+                default: 60s
+                description: The timeout for remote OCI Repository operations like
+                  pulling, defaults to 60s.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+                type: string
+              url:
+                description: |-
+                  URL is a reference to an OCI artifact repository hosted
+                  on a remote container registry.
+                pattern: ^oci://.*$
+                type: string
+              verify:
+                description: |-
+                  Verify contains the secret name containing the trusted public keys
+                  used to verify the signature and specifies which provider to use to check
+                  whether OCI image is authentic.
+                properties:
+                  matchOIDCIdentity:
+                    description: |-
+                      MatchOIDCIdentity specifies the identity matching criteria to use
+                      while verifying an OCI artifact which was signed using Cosign keyless
+                      signing. The artifact's identity is deemed to be verified if any of the
+                      specified matchers match against the identity.
+                    items:
+                      description: |-
+                        OIDCIdentityMatch specifies options for verifying the certificate identity,
+                        i.e. the issuer and the subject of the certificate.
+                      properties:
+                        issuer:
+                          description: |-
+                            Issuer specifies the regex pattern to match against to verify
+                            the OIDC issuer in the Fulcio certificate. The pattern must be a
+                            valid Go regular expression.
+                          type: string
+                        subject:
+                          description: |-
+                            Subject specifies the regex pattern to match against to verify
+                            the identity subject in the Fulcio certificate. The pattern must
+                            be a valid Go regular expression.
+                          type: string
+                      required:
+                      - issuer
+                      - subject
+                      type: object
+                    type: array
+                  provider:
+                    default: cosign
+                    description: Provider specifies the technology used to sign the
+                      OCI Artifact.
+                    enum:
+                    - cosign
+                    - notation
+                    type: string
+                  secretRef:
+                    description: |-
+                      SecretRef specifies the Kubernetes Secret containing the
+                      trusted public keys.
+                    properties:
+                      name:
+                        description: Name of the referent.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                required:
+                - provider
+                type: object
+            required:
+            - interval
+            - url
+            type: object
+          status:
+            default:
+              observedGeneration: -1
+            description: OCIRepositoryStatus defines the observed state of OCIRepository
+            properties:
+              artifact:
+                description: Artifact represents the output of the last successful
+                  OCI Repository sync.
+                properties:
+                  digest:
+                    description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
+                    pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
+                    type: string
+                  lastUpdateTime:
+                    description: |-
+                      LastUpdateTime is the timestamp corresponding to the last update of the
+                      Artifact.
+                    format: date-time
+                    type: string
+                  metadata:
+                    additionalProperties:
+                      type: string
+                    description: Metadata holds upstream information such as OCI annotations.
+                    type: object
+                  path:
+                    description: |-
+                      Path is the relative file path of the Artifact. It can be used to locate
+                      the file in the root of the Artifact storage on the local file system of
+                      the controller managing the Source.
+                    type: string
+                  revision:
+                    description: |-
+                      Revision is a human-readable identifier traceable in the origin source
+                      system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
+                    type: string
+                  size:
+                    description: Size is the number of bytes in the file.
+                    format: int64
+                    type: integer
+                  url:
+                    description: |-
+                      URL is the HTTP address of the Artifact as exposed by the controller
+                      managing the Source. It can be used to retrieve the Artifact for
+                      consumption, e.g. by another controller applying the Artifact contents.
+                    type: string
+                required:
+                - lastUpdateTime
+                - path
+                - revision
+                - url
+                type: object
+              conditions:
+                description: Conditions holds the conditions for the OCIRepository.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              contentConfigChecksum:
+                description: |-
+                  ContentConfigChecksum is a checksum of all the configurations related to
+                  the content of the source artifact:
+                   - .spec.ignore
+                   - .spec.layerSelector
+                  observed in .status.observedGeneration version of the object. This can
+                  be used to determine if the content configuration has changed and the
+                  artifact needs to be rebuilt.
+                  It has the format of `<algo>:<checksum>`, for example: `sha256:<checksum>`.
+
+
+                  Deprecated: Replaced with explicit fields for observed artifact content
+                  config in the status.
+                type: string
+              lastHandledReconcileAt:
+                description: |-
+                  LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value
+                  can be detected.
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the last observed generation.
+                format: int64
+                type: integer
+              observedIgnore:
+                description: |-
+                  ObservedIgnore is the observed exclusion patterns used for constructing
+                  the source artifact.
+                type: string
+              observedLayerSelector:
+                description: |-
+                  ObservedLayerSelector is the observed layer selector used for constructing
+                  the source artifact.
+                properties:
+                  mediaType:
+                    description: |-
+                      MediaType specifies the OCI media type of the layer
+                      which should be extracted from the OCI Artifact. The
+                      first layer matching this type is selected.
+                    type: string
+                  operation:
+                    description: |-
+                      Operation specifies how the selected layer should be processed.
+                      By default, the layer compressed content is extracted to storage.
+                      When the operation is set to 'copy', the layer compressed content
+                      is persisted to storage as it is.
+                    enum:
+                    - extract
+                    - copy
+                    type: string
+                type: object
+              url:
+                description: URL is the download link for the artifact output of the
+                  last OCI Repository sync.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -1,9 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- bases/source.toolkit.fluxcd.io_gitrepositories.yaml
-- bases/source.toolkit.fluxcd.io_helmrepositories.yaml
-- bases/source.toolkit.fluxcd.io_helmcharts.yaml
-- bases/source.toolkit.fluxcd.io_buckets.yaml
-- bases/source.toolkit.fluxcd.io_ocirepositories.yaml
+- bases/cd.qdrant.io_gitrepositories.yaml
+- bases/cd.qdrant.io_helmrepositories.yaml
+- bases/cd.qdrant.io_helmcharts.yaml
+- bases/cd.qdrant.io_buckets.yaml
+- bases/cd.qdrant.io_ocirepositories.yaml
 # +kubebuilder:scaffold:crdkustomizeresource

--- a/config/rbac/bucket_editor_role.yaml
+++ b/config/rbac/bucket_editor_role.yaml
@@ -5,7 +5,7 @@ metadata:
   name: bucket-editor-role
 rules:
 - apiGroups:
-  - source.toolkit.fluxcd.io
+  - cd.qdrant.io
   resources:
   - buckets
   verbs:
@@ -17,7 +17,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - source.toolkit.fluxcd.io
+  - cd.qdrant.io
   resources:
   - buckets/status
   verbs:

--- a/config/rbac/bucket_viewer_role.yaml
+++ b/config/rbac/bucket_viewer_role.yaml
@@ -5,7 +5,7 @@ metadata:
   name: bucket-viewer-role
 rules:
 - apiGroups:
-  - source.toolkit.fluxcd.io
+  - cd.qdrant.io
   resources:
   - buckets
   verbs:
@@ -13,7 +13,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - source.toolkit.fluxcd.io
+  - cd.qdrant.io
   resources:
   - buckets/status
   verbs:

--- a/config/rbac/gitrepository_editor_role.yaml
+++ b/config/rbac/gitrepository_editor_role.yaml
@@ -5,7 +5,7 @@ metadata:
   name: gitrepository-editor-role
 rules:
 - apiGroups:
-  - source.toolkit.fluxcd.io
+  - cd.qdrant.io
   resources:
   - gitrepositories
   verbs:
@@ -17,7 +17,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - source.toolkit.fluxcd.io
+  - cd.qdrant.io
   resources:
   - gitrepositories/status
   verbs:

--- a/config/rbac/gitrepository_viewer_role.yaml
+++ b/config/rbac/gitrepository_viewer_role.yaml
@@ -5,7 +5,7 @@ metadata:
   name: gitrepository-viewer-role
 rules:
 - apiGroups:
-  - source.toolkit.fluxcd.io
+  - cd.qdrant.io
   resources:
   - gitrepositories
   verbs:
@@ -13,7 +13,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - source.toolkit.fluxcd.io
+  - cd.qdrant.io
   resources:
   - gitrepositories/status
   verbs:

--- a/config/rbac/helmchart_editor_role.yaml
+++ b/config/rbac/helmchart_editor_role.yaml
@@ -5,7 +5,7 @@ metadata:
   name: helmchart-editor-role
 rules:
 - apiGroups:
-  - source.toolkit.fluxcd.io
+  - cd.qdrant.io
   resources:
   - helmcharts
   verbs:
@@ -17,7 +17,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - source.toolkit.fluxcd.io
+  - cd.qdrant.io
   resources:
   - helmcharts/status
   verbs:

--- a/config/rbac/helmchart_viewer_role.yaml
+++ b/config/rbac/helmchart_viewer_role.yaml
@@ -5,7 +5,7 @@ metadata:
   name: helmchart-viewer-role
 rules:
 - apiGroups:
-  - source.toolkit.fluxcd.io
+  - cd.qdrant.io
   resources:
   - helmcharts
   verbs:
@@ -13,7 +13,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - source.toolkit.fluxcd.io
+  - cd.qdrant.io
   resources:
   - helmcharts/status
   verbs:

--- a/config/rbac/helmrepository_editor_role.yaml
+++ b/config/rbac/helmrepository_editor_role.yaml
@@ -5,7 +5,7 @@ metadata:
   name: helmrepository-editor-role
 rules:
 - apiGroups:
-  - source.toolkit.fluxcd.io
+  - cd.qdrant.io
   resources:
   - helmrepositories
   verbs:
@@ -17,7 +17,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - source.toolkit.fluxcd.io
+  - cd.qdrant.io
   resources:
   - helmrepositories/status
   verbs:

--- a/config/rbac/helmrepository_viewer_role.yaml
+++ b/config/rbac/helmrepository_viewer_role.yaml
@@ -5,7 +5,7 @@ metadata:
   name: helmrepository-viewer-role
 rules:
 - apiGroups:
-  - source.toolkit.fluxcd.io
+  - cd.qdrant.io
   resources:
   - helmrepositories
   verbs:
@@ -13,7 +13,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - source.toolkit.fluxcd.io
+  - cd.qdrant.io
   resources:
   - helmrepositories/status
   verbs:

--- a/config/rbac/ocirepository_editor_role.yaml
+++ b/config/rbac/ocirepository_editor_role.yaml
@@ -5,7 +5,7 @@ metadata:
   name: ocirepository-editor-role
 rules:
 - apiGroups:
-  - source.toolkit.fluxcd.io
+  - cd.qdrant.io
   resources:
   - ocirepositories
   verbs:
@@ -17,7 +17,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - source.toolkit.fluxcd.io
+  - cd.qdrant.io
   resources:
   - ocirepositories/status
   verbs:

--- a/config/rbac/ocirepository_viewer_role.yaml
+++ b/config/rbac/ocirepository_viewer_role.yaml
@@ -5,7 +5,7 @@ metadata:
   name: ocirepository-viewer-role
 rules:
 - apiGroups:
-  - source.toolkit.fluxcd.io
+  - cd.qdrant.io
   resources:
   - ocirepositories
   verbs:
@@ -13,7 +13,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - source.toolkit.fluxcd.io
+  - cd.qdrant.io
   resources:
   - ocirepositories/status
   verbs:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -20,7 +20,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - source.toolkit.fluxcd.io
+  - cd.qdrant.io
   resources:
   - buckets
   verbs:
@@ -32,7 +32,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - source.toolkit.fluxcd.io
+  - cd.qdrant.io
   resources:
   - buckets/finalizers
   verbs:
@@ -42,7 +42,7 @@ rules:
   - patch
   - update
 - apiGroups:
-  - source.toolkit.fluxcd.io
+  - cd.qdrant.io
   resources:
   - buckets/status
   verbs:
@@ -50,7 +50,7 @@ rules:
   - patch
   - update
 - apiGroups:
-  - source.toolkit.fluxcd.io
+  - cd.qdrant.io
   resources:
   - gitrepositories
   verbs:
@@ -62,7 +62,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - source.toolkit.fluxcd.io
+  - cd.qdrant.io
   resources:
   - gitrepositories/finalizers
   verbs:
@@ -72,7 +72,7 @@ rules:
   - patch
   - update
 - apiGroups:
-  - source.toolkit.fluxcd.io
+  - cd.qdrant.io
   resources:
   - gitrepositories/status
   verbs:
@@ -80,7 +80,7 @@ rules:
   - patch
   - update
 - apiGroups:
-  - source.toolkit.fluxcd.io
+  - cd.qdrant.io
   resources:
   - helmcharts
   verbs:
@@ -92,7 +92,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - source.toolkit.fluxcd.io
+  - cd.qdrant.io
   resources:
   - helmcharts/finalizers
   verbs:
@@ -102,7 +102,7 @@ rules:
   - patch
   - update
 - apiGroups:
-  - source.toolkit.fluxcd.io
+  - cd.qdrant.io
   resources:
   - helmcharts/status
   verbs:
@@ -110,7 +110,7 @@ rules:
   - patch
   - update
 - apiGroups:
-  - source.toolkit.fluxcd.io
+  - cd.qdrant.io
   resources:
   - helmrepositories
   verbs:
@@ -122,7 +122,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - source.toolkit.fluxcd.io
+  - cd.qdrant.io
   resources:
   - helmrepositories/finalizers
   verbs:
@@ -132,7 +132,7 @@ rules:
   - patch
   - update
 - apiGroups:
-  - source.toolkit.fluxcd.io
+  - cd.qdrant.io
   resources:
   - helmrepositories/status
   verbs:
@@ -140,7 +140,7 @@ rules:
   - patch
   - update
 - apiGroups:
-  - source.toolkit.fluxcd.io
+  - cd.qdrant.io
   resources:
   - ocirepositories
   verbs:
@@ -152,7 +152,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - source.toolkit.fluxcd.io
+  - cd.qdrant.io
   resources:
   - ocirepositories/finalizers
   verbs:
@@ -162,7 +162,7 @@ rules:
   - patch
   - update
 - apiGroups:
-  - source.toolkit.fluxcd.io
+  - cd.qdrant.io
   resources:
   - ocirepositories/status
   verbs:

--- a/config/samples/source_v1_gitrepository.yaml
+++ b/config/samples/source_v1_gitrepository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1
+apiVersion: cd.qdrant.io/v1
 kind: GitRepository
 metadata:
   name: gitrepository-sample

--- a/config/samples/source_v1_helmchart_gitrepository.yaml
+++ b/config/samples/source_v1_helmchart_gitrepository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1
+apiVersion: cd.qdrant.io/v1
 kind: HelmChart
 metadata:
   name: helmchart-git-sample

--- a/config/samples/source_v1_helmchart_helmrepository-oci.yaml
+++ b/config/samples/source_v1_helmchart_helmrepository-oci.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1
+apiVersion: cd.qdrant.io/v1
 kind: HelmChart
 metadata:
   name: helmchart-sample-oci

--- a/config/samples/source_v1_helmchart_helmrepository.yaml
+++ b/config/samples/source_v1_helmchart_helmrepository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1
+apiVersion: cd.qdrant.io/v1
 kind: HelmChart
 metadata:
   name: helmchart-sample

--- a/config/samples/source_v1_helmrepository-oci.yaml
+++ b/config/samples/source_v1_helmrepository-oci.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1
+apiVersion: cd.qdrant.io/v1
 kind: HelmRepository
 metadata:
   name: helmrepository-sample-oci

--- a/config/samples/source_v1_helmrepository.yaml
+++ b/config/samples/source_v1_helmrepository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1
+apiVersion: cd.qdrant.io/v1
 kind: HelmRepository
 metadata:
   name: helmrepository-sample

--- a/config/samples/source_v1beta2_bucket.yaml
+++ b/config/samples/source_v1beta2_bucket.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: Bucket
 metadata:
   name: bucket-sample

--- a/config/samples/source_v1beta2_ocirepository.yaml
+++ b/config/samples/source_v1beta2_ocirepository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: OCIRepository
 metadata:
   name: ocirepository-sample

--- a/config/testdata/bucket/source.yaml
+++ b/config/testdata/bucket/source.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: cd.qdrant.io/v1beta1
 kind: Bucket
 metadata:
   name: podinfo

--- a/config/testdata/git/large-repo.yaml
+++ b/config/testdata/git/large-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: cd.qdrant.io/v1beta1
 kind: GitRepository
 metadata:
   name: large-repo

--- a/config/testdata/helmchart-from-bucket/source.yaml
+++ b/config/testdata/helmchart-from-bucket/source.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: cd.qdrant.io/v1beta1
 kind: Bucket
 metadata:
   name: charts
@@ -13,7 +13,7 @@ spec:
   secretRef:
     name: minio-credentials
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: cd.qdrant.io/v1beta1
 kind: HelmChart
 metadata:
   name: helmchart-bucket

--- a/config/testdata/helmchart-from-oci/notation.yaml
+++ b/config/testdata/helmchart-from-oci/notation.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1
+apiVersion: cd.qdrant.io/v1
 kind: HelmRepository
 metadata:
   name: podinfo-notation
@@ -8,7 +8,7 @@ spec:
   type: "oci"
   interval: 1m
 ---
-apiVersion: source.toolkit.fluxcd.io/v1
+apiVersion: cd.qdrant.io/v1
 kind: HelmChart
 metadata:
   name: podinfo-notation

--- a/config/testdata/helmchart-from-oci/source.yaml
+++ b/config/testdata/helmchart-from-oci/source.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: HelmRepository
 metadata:
   name: podinfo
@@ -8,7 +8,7 @@ spec:
   type: "oci"
   interval: 1m
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: HelmChart
 metadata:
   name: podinfo
@@ -20,7 +20,7 @@ spec:
   version: '6.1.*'
   interval: 1m
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: HelmChart
 metadata:
   name: podinfo-keyless

--- a/config/testdata/helmchart-valuesfile/gitrepository.yaml
+++ b/config/testdata/helmchart-valuesfile/gitrepository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: cd.qdrant.io/v1beta1
 kind: GitRepository
 metadata:
   name: podinfo

--- a/config/testdata/helmchart-valuesfile/helmchart_gitrepository.yaml
+++ b/config/testdata/helmchart-valuesfile/helmchart_gitrepository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: cd.qdrant.io/v1beta1
 kind: HelmChart
 metadata:
   name: podinfo-git

--- a/config/testdata/helmchart-valuesfile/helmchart_helmrepository.yaml
+++ b/config/testdata/helmchart-valuesfile/helmchart_helmrepository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: cd.qdrant.io/v1beta1
 kind: HelmChart
 metadata:
   name: podinfo

--- a/config/testdata/helmchart-valuesfile/helmrepository.yaml
+++ b/config/testdata/helmchart-valuesfile/helmrepository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: cd.qdrant.io/v1beta1
 kind: HelmRepository
 metadata:
   name: podinfo

--- a/config/testdata/ocirepository/signed-with-key.yaml
+++ b/config/testdata/ocirepository/signed-with-key.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: OCIRepository
 metadata:
   name: podinfo-deploy-signed-with-key

--- a/config/testdata/ocirepository/signed-with-keyless.yaml
+++ b/config/testdata/ocirepository/signed-with-keyless.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: OCIRepository
 metadata:
   name: podinfo-deploy-signed-with-keyless

--- a/config/testdata/ocirepository/signed-with-notation.yaml
+++ b/config/testdata/ocirepository/signed-with-notation.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: OCIRepository
 metadata:
   name: podinfo-deploy-signed-with-notation

--- a/docs/api/v1/source.md
+++ b/docs/api/v1/source.md
@@ -2,20 +2,20 @@
 <p>Packages:</p>
 <ul class="simple">
 <li>
-<a href="#source.toolkit.fluxcd.io%2fv1">source.toolkit.fluxcd.io/v1</a>
+<a href="#cd.qdrant.io%2fv1">cd.qdrant.io/v1</a>
 </li>
 </ul>
-<h2 id="source.toolkit.fluxcd.io/v1">source.toolkit.fluxcd.io/v1</h2>
+<h2 id="cd.qdrant.io/v1">cd.qdrant.io/v1</h2>
 <p>Package v1 contains API Schema definitions for the source v1 API group</p>
 Resource Types:
 <ul class="simple"><li>
-<a href="#source.toolkit.fluxcd.io/v1.GitRepository">GitRepository</a>
+<a href="#cd.qdrant.io/v1.GitRepository">GitRepository</a>
 </li><li>
-<a href="#source.toolkit.fluxcd.io/v1.HelmChart">HelmChart</a>
+<a href="#cd.qdrant.io/v1.HelmChart">HelmChart</a>
 </li><li>
-<a href="#source.toolkit.fluxcd.io/v1.HelmRepository">HelmRepository</a>
+<a href="#cd.qdrant.io/v1.HelmRepository">HelmRepository</a>
 </li></ul>
-<h3 id="source.toolkit.fluxcd.io/v1.GitRepository">GitRepository
+<h3 id="cd.qdrant.io/v1.GitRepository">GitRepository
 </h3>
 <p>GitRepository is the Schema for the gitrepositories API.</p>
 <div class="md-typeset__scrollwrap">
@@ -33,7 +33,7 @@ Resource Types:
 <code>apiVersion</code><br>
 string</td>
 <td>
-<code>source.toolkit.fluxcd.io/v1</code>
+<code>cd.qdrant.io/v1</code>
 </td>
 </tr>
 <tr>
@@ -63,7 +63,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code><br>
 <em>
-<a href="#source.toolkit.fluxcd.io/v1.GitRepositorySpec">
+<a href="#cd.qdrant.io/v1.GitRepositorySpec">
 GitRepositorySpec
 </a>
 </em>
@@ -135,7 +135,7 @@ Kubernetes meta/v1.Duration
 <td>
 <code>ref</code><br>
 <em>
-<a href="#source.toolkit.fluxcd.io/v1.GitRepositoryRef">
+<a href="#cd.qdrant.io/v1.GitRepositoryRef">
 GitRepositoryRef
 </a>
 </em>
@@ -150,7 +150,7 @@ changes, defaults to the &lsquo;master&rsquo; branch.</p>
 <td>
 <code>verify</code><br>
 <em>
-<a href="#source.toolkit.fluxcd.io/v1.GitRepositoryVerification">
+<a href="#cd.qdrant.io/v1.GitRepositoryVerification">
 GitRepositoryVerification
 </a>
 </em>
@@ -220,7 +220,7 @@ the GitRepository as cloned from the URL, using their default settings.</p>
 <td>
 <code>include</code><br>
 <em>
-<a href="#source.toolkit.fluxcd.io/v1.GitRepositoryInclude">
+<a href="#cd.qdrant.io/v1.GitRepositoryInclude">
 []GitRepositoryInclude
 </a>
 </em>
@@ -238,7 +238,7 @@ should be included in the Artifact produced for this GitRepository.</p>
 <td>
 <code>status</code><br>
 <em>
-<a href="#source.toolkit.fluxcd.io/v1.GitRepositoryStatus">
+<a href="#cd.qdrant.io/v1.GitRepositoryStatus">
 GitRepositoryStatus
 </a>
 </em>
@@ -250,7 +250,7 @@ GitRepositoryStatus
 </table>
 </div>
 </div>
-<h3 id="source.toolkit.fluxcd.io/v1.HelmChart">HelmChart
+<h3 id="cd.qdrant.io/v1.HelmChart">HelmChart
 </h3>
 <p>HelmChart is the Schema for the helmcharts API.</p>
 <div class="md-typeset__scrollwrap">
@@ -268,7 +268,7 @@ GitRepositoryStatus
 <code>apiVersion</code><br>
 string</td>
 <td>
-<code>source.toolkit.fluxcd.io/v1</code>
+<code>cd.qdrant.io/v1</code>
 </td>
 </tr>
 <tr>
@@ -298,7 +298,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code><br>
 <em>
-<a href="#source.toolkit.fluxcd.io/v1.HelmChartSpec">
+<a href="#cd.qdrant.io/v1.HelmChartSpec">
 HelmChartSpec
 </a>
 </em>
@@ -336,7 +336,7 @@ GitRepository and Bucket sources. Defaults to latest when omitted.</p>
 <td>
 <code>sourceRef</code><br>
 <em>
-<a href="#source.toolkit.fluxcd.io/v1.LocalHelmChartSourceReference">
+<a href="#cd.qdrant.io/v1.LocalHelmChartSourceReference">
 LocalHelmChartSourceReference
 </a>
 </em>
@@ -421,7 +421,7 @@ source.</p>
 <td>
 <code>verify</code><br>
 <em>
-<a href="#source.toolkit.fluxcd.io/v1.OCIRepositoryVerification">
+<a href="#cd.qdrant.io/v1.OCIRepositoryVerification">
 OCIRepositoryVerification
 </a>
 </em>
@@ -442,7 +442,7 @@ Chart dependencies, which are not bundled in the umbrella chart artifact, are no
 <td>
 <code>status</code><br>
 <em>
-<a href="#source.toolkit.fluxcd.io/v1.HelmChartStatus">
+<a href="#cd.qdrant.io/v1.HelmChartStatus">
 HelmChartStatus
 </a>
 </em>
@@ -454,7 +454,7 @@ HelmChartStatus
 </table>
 </div>
 </div>
-<h3 id="source.toolkit.fluxcd.io/v1.HelmRepository">HelmRepository
+<h3 id="cd.qdrant.io/v1.HelmRepository">HelmRepository
 </h3>
 <p>HelmRepository is the Schema for the helmrepositories API.</p>
 <div class="md-typeset__scrollwrap">
@@ -472,7 +472,7 @@ HelmChartStatus
 <code>apiVersion</code><br>
 string</td>
 <td>
-<code>source.toolkit.fluxcd.io/v1</code>
+<code>cd.qdrant.io/v1</code>
 </td>
 </tr>
 <tr>
@@ -502,7 +502,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code><br>
 <em>
-<a href="#source.toolkit.fluxcd.io/v1.HelmRepositorySpec">
+<a href="#cd.qdrant.io/v1.HelmRepositorySpec">
 HelmRepositorySpec
 </a>
 </em>
@@ -695,7 +695,7 @@ When not specified, defaults to &lsquo;generic&rsquo;.</p>
 <td>
 <code>status</code><br>
 <em>
-<a href="#source.toolkit.fluxcd.io/v1.HelmRepositoryStatus">
+<a href="#cd.qdrant.io/v1.HelmRepositoryStatus">
 HelmRepositoryStatus
 </a>
 </em>
@@ -707,13 +707,13 @@ HelmRepositoryStatus
 </table>
 </div>
 </div>
-<h3 id="source.toolkit.fluxcd.io/v1.Artifact">Artifact
+<h3 id="cd.qdrant.io/v1.Artifact">Artifact
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#source.toolkit.fluxcd.io/v1.GitRepositoryStatus">GitRepositoryStatus</a>, 
-<a href="#source.toolkit.fluxcd.io/v1.HelmChartStatus">HelmChartStatus</a>, 
-<a href="#source.toolkit.fluxcd.io/v1.HelmRepositoryStatus">HelmRepositoryStatus</a>)
+<a href="#cd.qdrant.io/v1.GitRepositoryStatus">GitRepositoryStatus</a>, 
+<a href="#cd.qdrant.io/v1.HelmChartStatus">HelmChartStatus</a>, 
+<a href="#cd.qdrant.io/v1.HelmRepositoryStatus">HelmRepositoryStatus</a>)
 </p>
 <p>Artifact represents the output of a Source reconciliation.</p>
 <div class="md-typeset__scrollwrap">
@@ -818,12 +818,12 @@ map[string]string
 </table>
 </div>
 </div>
-<h3 id="source.toolkit.fluxcd.io/v1.GitRepositoryInclude">GitRepositoryInclude
+<h3 id="cd.qdrant.io/v1.GitRepositoryInclude">GitRepositoryInclude
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#source.toolkit.fluxcd.io/v1.GitRepositorySpec">GitRepositorySpec</a>, 
-<a href="#source.toolkit.fluxcd.io/v1.GitRepositoryStatus">GitRepositoryStatus</a>)
+<a href="#cd.qdrant.io/v1.GitRepositorySpec">GitRepositorySpec</a>, 
+<a href="#cd.qdrant.io/v1.GitRepositoryStatus">GitRepositoryStatus</a>)
 </p>
 <p>GitRepositoryInclude specifies a local reference to a GitRepository which
 Artifact (sub-)contents must be included, and where they should be placed.</p>
@@ -881,11 +881,11 @@ the GitRepositoryRef.</p>
 </table>
 </div>
 </div>
-<h3 id="source.toolkit.fluxcd.io/v1.GitRepositoryRef">GitRepositoryRef
+<h3 id="cd.qdrant.io/v1.GitRepositoryRef">GitRepositoryRef
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#source.toolkit.fluxcd.io/v1.GitRepositorySpec">GitRepositorySpec</a>)
+<a href="#cd.qdrant.io/v1.GitRepositorySpec">GitRepositorySpec</a>)
 </p>
 <p>GitRepositoryRef specifies the Git reference to resolve and checkout.</p>
 <div class="md-typeset__scrollwrap">
@@ -966,11 +966,11 @@ the commit is expected to exist.</p>
 </table>
 </div>
 </div>
-<h3 id="source.toolkit.fluxcd.io/v1.GitRepositorySpec">GitRepositorySpec
+<h3 id="cd.qdrant.io/v1.GitRepositorySpec">GitRepositorySpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#source.toolkit.fluxcd.io/v1.GitRepository">GitRepository</a>)
+<a href="#cd.qdrant.io/v1.GitRepository">GitRepository</a>)
 </p>
 <p>GitRepositorySpec specifies the required configuration to produce an
 Artifact for a Git repository.</p>
@@ -1047,7 +1047,7 @@ Kubernetes meta/v1.Duration
 <td>
 <code>ref</code><br>
 <em>
-<a href="#source.toolkit.fluxcd.io/v1.GitRepositoryRef">
+<a href="#cd.qdrant.io/v1.GitRepositoryRef">
 GitRepositoryRef
 </a>
 </em>
@@ -1062,7 +1062,7 @@ changes, defaults to the &lsquo;master&rsquo; branch.</p>
 <td>
 <code>verify</code><br>
 <em>
-<a href="#source.toolkit.fluxcd.io/v1.GitRepositoryVerification">
+<a href="#cd.qdrant.io/v1.GitRepositoryVerification">
 GitRepositoryVerification
 </a>
 </em>
@@ -1132,7 +1132,7 @@ the GitRepository as cloned from the URL, using their default settings.</p>
 <td>
 <code>include</code><br>
 <em>
-<a href="#source.toolkit.fluxcd.io/v1.GitRepositoryInclude">
+<a href="#cd.qdrant.io/v1.GitRepositoryInclude">
 []GitRepositoryInclude
 </a>
 </em>
@@ -1147,11 +1147,11 @@ should be included in the Artifact produced for this GitRepository.</p>
 </table>
 </div>
 </div>
-<h3 id="source.toolkit.fluxcd.io/v1.GitRepositoryStatus">GitRepositoryStatus
+<h3 id="cd.qdrant.io/v1.GitRepositoryStatus">GitRepositoryStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#source.toolkit.fluxcd.io/v1.GitRepository">GitRepository</a>)
+<a href="#cd.qdrant.io/v1.GitRepository">GitRepository</a>)
 </p>
 <p>GitRepositoryStatus records the observed state of a Git repository.</p>
 <div class="md-typeset__scrollwrap">
@@ -1195,7 +1195,7 @@ object.</p>
 <td>
 <code>artifact</code><br>
 <em>
-<a href="#source.toolkit.fluxcd.io/v1.Artifact">
+<a href="#cd.qdrant.io/v1.Artifact">
 Artifact
 </a>
 </em>
@@ -1209,7 +1209,7 @@ Artifact
 <td>
 <code>includedArtifacts</code><br>
 <em>
-<a href="#source.toolkit.fluxcd.io/v1.Artifact">
+<a href="#cd.qdrant.io/v1.Artifact">
 []Artifact
 </a>
 </em>
@@ -1250,7 +1250,7 @@ configuration used to produce the current Artifact.</p>
 <td>
 <code>observedInclude</code><br>
 <em>
-<a href="#source.toolkit.fluxcd.io/v1.GitRepositoryInclude">
+<a href="#cd.qdrant.io/v1.GitRepositoryInclude">
 []GitRepositoryInclude
 </a>
 </em>
@@ -1265,7 +1265,7 @@ produce the current Artifact.</p>
 <td>
 <code>sourceVerificationMode</code><br>
 <em>
-<a href="#source.toolkit.fluxcd.io/v1.GitVerificationMode">
+<a href="#cd.qdrant.io/v1.GitVerificationMode">
 GitVerificationMode
 </a>
 </em>
@@ -1295,11 +1295,11 @@ github.com/fluxcd/pkg/apis/meta.ReconcileRequestStatus
 </table>
 </div>
 </div>
-<h3 id="source.toolkit.fluxcd.io/v1.GitRepositoryVerification">GitRepositoryVerification
+<h3 id="cd.qdrant.io/v1.GitRepositoryVerification">GitRepositoryVerification
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#source.toolkit.fluxcd.io/v1.GitRepositorySpec">GitRepositorySpec</a>)
+<a href="#cd.qdrant.io/v1.GitRepositorySpec">GitRepositorySpec</a>)
 </p>
 <p>GitRepositoryVerification specifies the Git commit signature verification
 strategy.</p>
@@ -1317,7 +1317,7 @@ strategy.</p>
 <td>
 <code>mode</code><br>
 <em>
-<a href="#source.toolkit.fluxcd.io/v1.GitVerificationMode">
+<a href="#cd.qdrant.io/v1.GitVerificationMode">
 GitVerificationMode
 </a>
 </em>
@@ -1348,19 +1348,19 @@ authors.</p>
 </table>
 </div>
 </div>
-<h3 id="source.toolkit.fluxcd.io/v1.GitVerificationMode">GitVerificationMode
+<h3 id="cd.qdrant.io/v1.GitVerificationMode">GitVerificationMode
 (<code>string</code> alias)</h3>
 <p>
 (<em>Appears on:</em>
-<a href="#source.toolkit.fluxcd.io/v1.GitRepositoryStatus">GitRepositoryStatus</a>, 
-<a href="#source.toolkit.fluxcd.io/v1.GitRepositoryVerification">GitRepositoryVerification</a>)
+<a href="#cd.qdrant.io/v1.GitRepositoryStatus">GitRepositoryStatus</a>, 
+<a href="#cd.qdrant.io/v1.GitRepositoryVerification">GitRepositoryVerification</a>)
 </p>
 <p>GitVerificationMode specifies the verification mode for a Git repository.</p>
-<h3 id="source.toolkit.fluxcd.io/v1.HelmChartSpec">HelmChartSpec
+<h3 id="cd.qdrant.io/v1.HelmChartSpec">HelmChartSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#source.toolkit.fluxcd.io/v1.HelmChart">HelmChart</a>)
+<a href="#cd.qdrant.io/v1.HelmChart">HelmChart</a>)
 </p>
 <p>HelmChartSpec specifies the desired state of a Helm chart.</p>
 <div class="md-typeset__scrollwrap">
@@ -1402,7 +1402,7 @@ GitRepository and Bucket sources. Defaults to latest when omitted.</p>
 <td>
 <code>sourceRef</code><br>
 <em>
-<a href="#source.toolkit.fluxcd.io/v1.LocalHelmChartSourceReference">
+<a href="#cd.qdrant.io/v1.LocalHelmChartSourceReference">
 LocalHelmChartSourceReference
 </a>
 </em>
@@ -1487,7 +1487,7 @@ source.</p>
 <td>
 <code>verify</code><br>
 <em>
-<a href="#source.toolkit.fluxcd.io/v1.OCIRepositoryVerification">
+<a href="#cd.qdrant.io/v1.OCIRepositoryVerification">
 OCIRepositoryVerification
 </a>
 </em>
@@ -1505,11 +1505,11 @@ Chart dependencies, which are not bundled in the umbrella chart artifact, are no
 </table>
 </div>
 </div>
-<h3 id="source.toolkit.fluxcd.io/v1.HelmChartStatus">HelmChartStatus
+<h3 id="cd.qdrant.io/v1.HelmChartStatus">HelmChartStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#source.toolkit.fluxcd.io/v1.HelmChart">HelmChart</a>)
+<a href="#cd.qdrant.io/v1.HelmChart">HelmChart</a>)
 </p>
 <p>HelmChartStatus records the observed state of the HelmChart.</p>
 <div class="md-typeset__scrollwrap">
@@ -1607,7 +1607,7 @@ BucketStatus.Artifact data is recommended.</p>
 <td>
 <code>artifact</code><br>
 <em>
-<a href="#source.toolkit.fluxcd.io/v1.Artifact">
+<a href="#cd.qdrant.io/v1.Artifact">
 Artifact
 </a>
 </em>
@@ -1636,11 +1636,11 @@ github.com/fluxcd/pkg/apis/meta.ReconcileRequestStatus
 </table>
 </div>
 </div>
-<h3 id="source.toolkit.fluxcd.io/v1.HelmRepositorySpec">HelmRepositorySpec
+<h3 id="cd.qdrant.io/v1.HelmRepositorySpec">HelmRepositorySpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#source.toolkit.fluxcd.io/v1.HelmRepository">HelmRepository</a>)
+<a href="#cd.qdrant.io/v1.HelmRepository">HelmRepository</a>)
 </p>
 <p>HelmRepositorySpec specifies the required configuration to produce an
 Artifact for a Helm repository index YAML.</p>
@@ -1835,11 +1835,11 @@ When not specified, defaults to &lsquo;generic&rsquo;.</p>
 </table>
 </div>
 </div>
-<h3 id="source.toolkit.fluxcd.io/v1.HelmRepositoryStatus">HelmRepositoryStatus
+<h3 id="cd.qdrant.io/v1.HelmRepositoryStatus">HelmRepositoryStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#source.toolkit.fluxcd.io/v1.HelmRepository">HelmRepository</a>)
+<a href="#cd.qdrant.io/v1.HelmRepository">HelmRepository</a>)
 </p>
 <p>HelmRepositoryStatus records the observed state of the HelmRepository.</p>
 <div class="md-typeset__scrollwrap">
@@ -1897,7 +1897,7 @@ HelmRepositoryStatus.Artifact data is recommended.</p>
 <td>
 <code>artifact</code><br>
 <em>
-<a href="#source.toolkit.fluxcd.io/v1.Artifact">
+<a href="#cd.qdrant.io/v1.Artifact">
 Artifact
 </a>
 </em>
@@ -1926,11 +1926,11 @@ github.com/fluxcd/pkg/apis/meta.ReconcileRequestStatus
 </table>
 </div>
 </div>
-<h3 id="source.toolkit.fluxcd.io/v1.LocalHelmChartSourceReference">LocalHelmChartSourceReference
+<h3 id="cd.qdrant.io/v1.LocalHelmChartSourceReference">LocalHelmChartSourceReference
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#source.toolkit.fluxcd.io/v1.HelmChartSpec">HelmChartSpec</a>)
+<a href="#cd.qdrant.io/v1.HelmChartSpec">HelmChartSpec</a>)
 </p>
 <p>LocalHelmChartSourceReference contains enough information to let you locate
 the typed referenced object at namespace level.</p>
@@ -1983,11 +1983,11 @@ string
 </table>
 </div>
 </div>
-<h3 id="source.toolkit.fluxcd.io/v1.OCIRepositoryVerification">OCIRepositoryVerification
+<h3 id="cd.qdrant.io/v1.OCIRepositoryVerification">OCIRepositoryVerification
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#source.toolkit.fluxcd.io/v1.HelmChartSpec">HelmChartSpec</a>)
+<a href="#cd.qdrant.io/v1.HelmChartSpec">HelmChartSpec</a>)
 </p>
 <p>OCIRepositoryVerification verifies the authenticity of an OCI Artifact</p>
 <div class="md-typeset__scrollwrap">
@@ -2030,7 +2030,7 @@ trusted public keys.</p>
 <td>
 <code>matchOIDCIdentity</code><br>
 <em>
-<a href="#source.toolkit.fluxcd.io/v1.OIDCIdentityMatch">
+<a href="#cd.qdrant.io/v1.OIDCIdentityMatch">
 []OIDCIdentityMatch
 </a>
 </em>
@@ -2047,11 +2047,11 @@ specified matchers match against the identity.</p>
 </table>
 </div>
 </div>
-<h3 id="source.toolkit.fluxcd.io/v1.OIDCIdentityMatch">OIDCIdentityMatch
+<h3 id="cd.qdrant.io/v1.OIDCIdentityMatch">OIDCIdentityMatch
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#source.toolkit.fluxcd.io/v1.OCIRepositoryVerification">OCIRepositoryVerification</a>)
+<a href="#cd.qdrant.io/v1.OCIRepositoryVerification">OCIRepositoryVerification</a>)
 </p>
 <p>OIDCIdentityMatch specifies options for verifying the certificate identity,
 i.e. the issuer and the subject of the certificate.</p>
@@ -2095,11 +2095,11 @@ be a valid Go regular expression.</p>
 </table>
 </div>
 </div>
-<h3 id="source.toolkit.fluxcd.io/v1.Source">Source
+<h3 id="cd.qdrant.io/v1.Source">Source
 </h3>
 <p>Source interface must be supported by all API types.
 Source is the interface that provides generic access to the Artifact and
-interval. It must be supported by all kinds of the source.toolkit.fluxcd.io
+interval. It must be supported by all kinds of the cd.qdrant.io
 API group.</p>
 <div class="admonition note">
 <p class="last">This page was automatically generated with <code>gen-crd-api-reference-docs</code></p>

--- a/docs/api/v1beta2/source.md
+++ b/docs/api/v1beta2/source.md
@@ -2,24 +2,24 @@
 <p>Packages:</p>
 <ul class="simple">
 <li>
-<a href="#source.toolkit.fluxcd.io%2fv1beta2">source.toolkit.fluxcd.io/v1beta2</a>
+<a href="#cd.qdrant.io%2fv1beta2">cd.qdrant.io/v1beta2</a>
 </li>
 </ul>
-<h2 id="source.toolkit.fluxcd.io/v1beta2">source.toolkit.fluxcd.io/v1beta2</h2>
+<h2 id="cd.qdrant.io/v1beta2">cd.qdrant.io/v1beta2</h2>
 <p>Package v1beta2 contains API Schema definitions for the source v1beta2 API group</p>
 Resource Types:
 <ul class="simple"><li>
-<a href="#source.toolkit.fluxcd.io/v1beta2.Bucket">Bucket</a>
+<a href="#cd.qdrant.io/v1beta2.Bucket">Bucket</a>
 </li><li>
-<a href="#source.toolkit.fluxcd.io/v1beta2.GitRepository">GitRepository</a>
+<a href="#cd.qdrant.io/v1beta2.GitRepository">GitRepository</a>
 </li><li>
-<a href="#source.toolkit.fluxcd.io/v1beta2.HelmChart">HelmChart</a>
+<a href="#cd.qdrant.io/v1beta2.HelmChart">HelmChart</a>
 </li><li>
-<a href="#source.toolkit.fluxcd.io/v1beta2.HelmRepository">HelmRepository</a>
+<a href="#cd.qdrant.io/v1beta2.HelmRepository">HelmRepository</a>
 </li><li>
-<a href="#source.toolkit.fluxcd.io/v1beta2.OCIRepository">OCIRepository</a>
+<a href="#cd.qdrant.io/v1beta2.OCIRepository">OCIRepository</a>
 </li></ul>
-<h3 id="source.toolkit.fluxcd.io/v1beta2.Bucket">Bucket
+<h3 id="cd.qdrant.io/v1beta2.Bucket">Bucket
 </h3>
 <p>Bucket is the Schema for the buckets API.</p>
 <div class="md-typeset__scrollwrap">
@@ -37,7 +37,7 @@ Resource Types:
 <code>apiVersion</code><br>
 string</td>
 <td>
-<code>source.toolkit.fluxcd.io/v1beta2</code>
+<code>cd.qdrant.io/v1beta2</code>
 </td>
 </tr>
 <tr>
@@ -67,7 +67,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code><br>
 <em>
-<a href="#source.toolkit.fluxcd.io/v1beta2.BucketSpec">
+<a href="#cd.qdrant.io/v1beta2.BucketSpec">
 BucketSpec
 </a>
 </em>
@@ -116,7 +116,7 @@ string
 <td>
 <code>sts</code><br>
 <em>
-<a href="#source.toolkit.fluxcd.io/v1beta2.BucketSTSSpec">
+<a href="#cd.qdrant.io/v1beta2.BucketSTSSpec">
 BucketSTSSpec
 </a>
 </em>
@@ -300,7 +300,7 @@ NOTE: Not implemented, provisional as of <a href="https://github.com/fluxcd/flux
 <td>
 <code>status</code><br>
 <em>
-<a href="#source.toolkit.fluxcd.io/v1beta2.BucketStatus">
+<a href="#cd.qdrant.io/v1beta2.BucketStatus">
 BucketStatus
 </a>
 </em>
@@ -312,7 +312,7 @@ BucketStatus
 </table>
 </div>
 </div>
-<h3 id="source.toolkit.fluxcd.io/v1beta2.GitRepository">GitRepository
+<h3 id="cd.qdrant.io/v1beta2.GitRepository">GitRepository
 </h3>
 <p>GitRepository is the Schema for the gitrepositories API.</p>
 <div class="md-typeset__scrollwrap">
@@ -330,7 +330,7 @@ BucketStatus
 <code>apiVersion</code><br>
 string</td>
 <td>
-<code>source.toolkit.fluxcd.io/v1beta2</code>
+<code>cd.qdrant.io/v1beta2</code>
 </td>
 </tr>
 <tr>
@@ -360,7 +360,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code><br>
 <em>
-<a href="#source.toolkit.fluxcd.io/v1beta2.GitRepositorySpec">
+<a href="#cd.qdrant.io/v1beta2.GitRepositorySpec">
 GitRepositorySpec
 </a>
 </em>
@@ -430,7 +430,7 @@ Kubernetes meta/v1.Duration
 <td>
 <code>ref</code><br>
 <em>
-<a href="#source.toolkit.fluxcd.io/v1beta2.GitRepositoryRef">
+<a href="#cd.qdrant.io/v1beta2.GitRepositoryRef">
 GitRepositoryRef
 </a>
 </em>
@@ -445,7 +445,7 @@ changes, defaults to the &lsquo;master&rsquo; branch.</p>
 <td>
 <code>verify</code><br>
 <em>
-<a href="#source.toolkit.fluxcd.io/v1beta2.GitRepositoryVerification">
+<a href="#cd.qdrant.io/v1beta2.GitRepositoryVerification">
 GitRepositoryVerification
 </a>
 </em>
@@ -515,7 +515,7 @@ the GitRepository as cloned from the URL, using their default settings.</p>
 <td>
 <code>include</code><br>
 <em>
-<a href="#source.toolkit.fluxcd.io/v1beta2.GitRepositoryInclude">
+<a href="#cd.qdrant.io/v1beta2.GitRepositoryInclude">
 []GitRepositoryInclude
 </a>
 </em>
@@ -548,7 +548,7 @@ NOTE: Not implemented, provisional as of <a href="https://github.com/fluxcd/flux
 <td>
 <code>status</code><br>
 <em>
-<a href="#source.toolkit.fluxcd.io/v1beta2.GitRepositoryStatus">
+<a href="#cd.qdrant.io/v1beta2.GitRepositoryStatus">
 GitRepositoryStatus
 </a>
 </em>
@@ -560,7 +560,7 @@ GitRepositoryStatus
 </table>
 </div>
 </div>
-<h3 id="source.toolkit.fluxcd.io/v1beta2.HelmChart">HelmChart
+<h3 id="cd.qdrant.io/v1beta2.HelmChart">HelmChart
 </h3>
 <p>HelmChart is the Schema for the helmcharts API.</p>
 <div class="md-typeset__scrollwrap">
@@ -578,7 +578,7 @@ GitRepositoryStatus
 <code>apiVersion</code><br>
 string</td>
 <td>
-<code>source.toolkit.fluxcd.io/v1beta2</code>
+<code>cd.qdrant.io/v1beta2</code>
 </td>
 </tr>
 <tr>
@@ -608,7 +608,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code><br>
 <em>
-<a href="#source.toolkit.fluxcd.io/v1beta2.HelmChartSpec">
+<a href="#cd.qdrant.io/v1beta2.HelmChartSpec">
 HelmChartSpec
 </a>
 </em>
@@ -646,7 +646,7 @@ GitRepository and Bucket sources. Defaults to latest when omitted.</p>
 <td>
 <code>sourceRef</code><br>
 <em>
-<a href="#source.toolkit.fluxcd.io/v1beta2.LocalHelmChartSourceReference">
+<a href="#cd.qdrant.io/v1beta2.LocalHelmChartSourceReference">
 LocalHelmChartSourceReference
 </a>
 </em>
@@ -783,7 +783,7 @@ Chart dependencies, which are not bundled in the umbrella chart artifact, are no
 <td>
 <code>status</code><br>
 <em>
-<a href="#source.toolkit.fluxcd.io/v1beta2.HelmChartStatus">
+<a href="#cd.qdrant.io/v1beta2.HelmChartStatus">
 HelmChartStatus
 </a>
 </em>
@@ -795,7 +795,7 @@ HelmChartStatus
 </table>
 </div>
 </div>
-<h3 id="source.toolkit.fluxcd.io/v1beta2.HelmRepository">HelmRepository
+<h3 id="cd.qdrant.io/v1beta2.HelmRepository">HelmRepository
 </h3>
 <p>HelmRepository is the Schema for the helmrepositories API.</p>
 <div class="md-typeset__scrollwrap">
@@ -813,7 +813,7 @@ HelmChartStatus
 <code>apiVersion</code><br>
 string</td>
 <td>
-<code>source.toolkit.fluxcd.io/v1beta2</code>
+<code>cd.qdrant.io/v1beta2</code>
 </td>
 </tr>
 <tr>
@@ -843,7 +843,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code><br>
 <em>
-<a href="#source.toolkit.fluxcd.io/v1beta2.HelmRepositorySpec">
+<a href="#cd.qdrant.io/v1beta2.HelmRepositorySpec">
 HelmRepositorySpec
 </a>
 </em>
@@ -1036,7 +1036,7 @@ When not specified, defaults to &lsquo;generic&rsquo;.</p>
 <td>
 <code>status</code><br>
 <em>
-<a href="#source.toolkit.fluxcd.io/v1beta2.HelmRepositoryStatus">
+<a href="#cd.qdrant.io/v1beta2.HelmRepositoryStatus">
 HelmRepositoryStatus
 </a>
 </em>
@@ -1048,7 +1048,7 @@ HelmRepositoryStatus
 </table>
 </div>
 </div>
-<h3 id="source.toolkit.fluxcd.io/v1beta2.OCIRepository">OCIRepository
+<h3 id="cd.qdrant.io/v1beta2.OCIRepository">OCIRepository
 </h3>
 <p>OCIRepository is the Schema for the ocirepositories API</p>
 <div class="md-typeset__scrollwrap">
@@ -1066,7 +1066,7 @@ HelmRepositoryStatus
 <code>apiVersion</code><br>
 string</td>
 <td>
-<code>source.toolkit.fluxcd.io/v1beta2</code>
+<code>cd.qdrant.io/v1beta2</code>
 </td>
 </tr>
 <tr>
@@ -1096,7 +1096,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code><br>
 <em>
-<a href="#source.toolkit.fluxcd.io/v1beta2.OCIRepositorySpec">
+<a href="#cd.qdrant.io/v1beta2.OCIRepositorySpec">
 OCIRepositorySpec
 </a>
 </em>
@@ -1121,7 +1121,7 @@ on a remote container registry.</p>
 <td>
 <code>ref</code><br>
 <em>
-<a href="#source.toolkit.fluxcd.io/v1beta2.OCIRepositoryRef">
+<a href="#cd.qdrant.io/v1beta2.OCIRepositoryRef">
 OCIRepositoryRef
 </a>
 </em>
@@ -1136,7 +1136,7 @@ defaults to the latest tag.</p>
 <td>
 <code>layerSelector</code><br>
 <em>
-<a href="#source.toolkit.fluxcd.io/v1beta2.OCILayerSelector">
+<a href="#cd.qdrant.io/v1beta2.OCILayerSelector">
 OCILayerSelector
 </a>
 </em>
@@ -1322,7 +1322,7 @@ bool
 <td>
 <code>status</code><br>
 <em>
-<a href="#source.toolkit.fluxcd.io/v1beta2.OCIRepositoryStatus">
+<a href="#cd.qdrant.io/v1beta2.OCIRepositoryStatus">
 OCIRepositoryStatus
 </a>
 </em>
@@ -1334,7 +1334,7 @@ OCIRepositoryStatus
 </table>
 </div>
 </div>
-<h3 id="source.toolkit.fluxcd.io/v1beta2.Artifact">Artifact
+<h3 id="cd.qdrant.io/v1beta2.Artifact">Artifact
 </h3>
 <p>Artifact represents the output of a Source reconciliation.</p>
 <p>Deprecated: use Artifact from api/v1 instead. This type will be removed in
@@ -1455,11 +1455,11 @@ map[string]string
 </table>
 </div>
 </div>
-<h3 id="source.toolkit.fluxcd.io/v1beta2.BucketSTSSpec">BucketSTSSpec
+<h3 id="cd.qdrant.io/v1beta2.BucketSTSSpec">BucketSTSSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#source.toolkit.fluxcd.io/v1beta2.BucketSpec">BucketSpec</a>)
+<a href="#cd.qdrant.io/v1beta2.BucketSpec">BucketSpec</a>)
 </p>
 <p>BucketSTSSpec specifies the required configuration to use a Security Token
 Service for fetching temporary credentials to authenticate in a Bucket
@@ -1501,11 +1501,11 @@ where temporary credentials will be fetched.</p>
 </table>
 </div>
 </div>
-<h3 id="source.toolkit.fluxcd.io/v1beta2.BucketSpec">BucketSpec
+<h3 id="cd.qdrant.io/v1beta2.BucketSpec">BucketSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#source.toolkit.fluxcd.io/v1beta2.Bucket">Bucket</a>)
+<a href="#cd.qdrant.io/v1beta2.Bucket">Bucket</a>)
 </p>
 <p>BucketSpec specifies the required configuration to produce an Artifact for
 an object storage bucket.</p>
@@ -1559,7 +1559,7 @@ string
 <td>
 <code>sts</code><br>
 <em>
-<a href="#source.toolkit.fluxcd.io/v1beta2.BucketSTSSpec">
+<a href="#cd.qdrant.io/v1beta2.BucketSTSSpec">
 BucketSTSSpec
 </a>
 </em>
@@ -1740,11 +1740,11 @@ NOTE: Not implemented, provisional as of <a href="https://github.com/fluxcd/flux
 </table>
 </div>
 </div>
-<h3 id="source.toolkit.fluxcd.io/v1beta2.BucketStatus">BucketStatus
+<h3 id="cd.qdrant.io/v1beta2.BucketStatus">BucketStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#source.toolkit.fluxcd.io/v1beta2.Bucket">Bucket</a>)
+<a href="#cd.qdrant.io/v1beta2.Bucket">Bucket</a>)
 </p>
 <p>BucketStatus records the observed state of a Bucket.</p>
 <div class="md-typeset__scrollwrap">
@@ -1843,12 +1843,12 @@ github.com/fluxcd/pkg/apis/meta.ReconcileRequestStatus
 </table>
 </div>
 </div>
-<h3 id="source.toolkit.fluxcd.io/v1beta2.GitRepositoryInclude">GitRepositoryInclude
+<h3 id="cd.qdrant.io/v1beta2.GitRepositoryInclude">GitRepositoryInclude
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#source.toolkit.fluxcd.io/v1beta2.GitRepositorySpec">GitRepositorySpec</a>, 
-<a href="#source.toolkit.fluxcd.io/v1beta2.GitRepositoryStatus">GitRepositoryStatus</a>)
+<a href="#cd.qdrant.io/v1beta2.GitRepositorySpec">GitRepositorySpec</a>, 
+<a href="#cd.qdrant.io/v1beta2.GitRepositoryStatus">GitRepositoryStatus</a>)
 </p>
 <p>GitRepositoryInclude specifies a local reference to a GitRepository which
 Artifact (sub-)contents must be included, and where they should be placed.</p>
@@ -1906,11 +1906,11 @@ the GitRepositoryRef.</p>
 </table>
 </div>
 </div>
-<h3 id="source.toolkit.fluxcd.io/v1beta2.GitRepositoryRef">GitRepositoryRef
+<h3 id="cd.qdrant.io/v1beta2.GitRepositoryRef">GitRepositoryRef
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#source.toolkit.fluxcd.io/v1beta2.GitRepositorySpec">GitRepositorySpec</a>)
+<a href="#cd.qdrant.io/v1beta2.GitRepositorySpec">GitRepositorySpec</a>)
 </p>
 <p>GitRepositoryRef specifies the Git reference to resolve and checkout.</p>
 <div class="md-typeset__scrollwrap">
@@ -1991,11 +1991,11 @@ the commit is expected to exist.</p>
 </table>
 </div>
 </div>
-<h3 id="source.toolkit.fluxcd.io/v1beta2.GitRepositorySpec">GitRepositorySpec
+<h3 id="cd.qdrant.io/v1beta2.GitRepositorySpec">GitRepositorySpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#source.toolkit.fluxcd.io/v1beta2.GitRepository">GitRepository</a>)
+<a href="#cd.qdrant.io/v1beta2.GitRepository">GitRepository</a>)
 </p>
 <p>GitRepositorySpec specifies the required configuration to produce an
 Artifact for a Git repository.</p>
@@ -2070,7 +2070,7 @@ Kubernetes meta/v1.Duration
 <td>
 <code>ref</code><br>
 <em>
-<a href="#source.toolkit.fluxcd.io/v1beta2.GitRepositoryRef">
+<a href="#cd.qdrant.io/v1beta2.GitRepositoryRef">
 GitRepositoryRef
 </a>
 </em>
@@ -2085,7 +2085,7 @@ changes, defaults to the &lsquo;master&rsquo; branch.</p>
 <td>
 <code>verify</code><br>
 <em>
-<a href="#source.toolkit.fluxcd.io/v1beta2.GitRepositoryVerification">
+<a href="#cd.qdrant.io/v1beta2.GitRepositoryVerification">
 GitRepositoryVerification
 </a>
 </em>
@@ -2155,7 +2155,7 @@ the GitRepository as cloned from the URL, using their default settings.</p>
 <td>
 <code>include</code><br>
 <em>
-<a href="#source.toolkit.fluxcd.io/v1beta2.GitRepositoryInclude">
+<a href="#cd.qdrant.io/v1beta2.GitRepositoryInclude">
 []GitRepositoryInclude
 </a>
 </em>
@@ -2185,11 +2185,11 @@ NOTE: Not implemented, provisional as of <a href="https://github.com/fluxcd/flux
 </table>
 </div>
 </div>
-<h3 id="source.toolkit.fluxcd.io/v1beta2.GitRepositoryStatus">GitRepositoryStatus
+<h3 id="cd.qdrant.io/v1beta2.GitRepositoryStatus">GitRepositoryStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#source.toolkit.fluxcd.io/v1beta2.GitRepository">GitRepository</a>)
+<a href="#cd.qdrant.io/v1beta2.GitRepository">GitRepository</a>)
 </p>
 <p>GitRepositoryStatus records the observed state of a Git repository.</p>
 <div class="md-typeset__scrollwrap">
@@ -2324,7 +2324,7 @@ configuration used to produce the current Artifact.</p>
 <td>
 <code>observedInclude</code><br>
 <em>
-<a href="#source.toolkit.fluxcd.io/v1beta2.GitRepositoryInclude">
+<a href="#cd.qdrant.io/v1beta2.GitRepositoryInclude">
 []GitRepositoryInclude
 </a>
 </em>
@@ -2354,11 +2354,11 @@ github.com/fluxcd/pkg/apis/meta.ReconcileRequestStatus
 </table>
 </div>
 </div>
-<h3 id="source.toolkit.fluxcd.io/v1beta2.GitRepositoryVerification">GitRepositoryVerification
+<h3 id="cd.qdrant.io/v1beta2.GitRepositoryVerification">GitRepositoryVerification
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#source.toolkit.fluxcd.io/v1beta2.GitRepositorySpec">GitRepositorySpec</a>)
+<a href="#cd.qdrant.io/v1beta2.GitRepositorySpec">GitRepositorySpec</a>)
 </p>
 <p>GitRepositoryVerification specifies the Git commit signature verification
 strategy.</p>
@@ -2401,11 +2401,11 @@ authors.</p>
 </table>
 </div>
 </div>
-<h3 id="source.toolkit.fluxcd.io/v1beta2.HelmChartSpec">HelmChartSpec
+<h3 id="cd.qdrant.io/v1beta2.HelmChartSpec">HelmChartSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#source.toolkit.fluxcd.io/v1beta2.HelmChart">HelmChart</a>)
+<a href="#cd.qdrant.io/v1beta2.HelmChart">HelmChart</a>)
 </p>
 <p>HelmChartSpec specifies the desired state of a Helm chart.</p>
 <div class="md-typeset__scrollwrap">
@@ -2447,7 +2447,7 @@ GitRepository and Bucket sources. Defaults to latest when omitted.</p>
 <td>
 <code>sourceRef</code><br>
 <em>
-<a href="#source.toolkit.fluxcd.io/v1beta2.LocalHelmChartSourceReference">
+<a href="#cd.qdrant.io/v1beta2.LocalHelmChartSourceReference">
 LocalHelmChartSourceReference
 </a>
 </em>
@@ -2581,11 +2581,11 @@ Chart dependencies, which are not bundled in the umbrella chart artifact, are no
 </table>
 </div>
 </div>
-<h3 id="source.toolkit.fluxcd.io/v1beta2.HelmChartStatus">HelmChartStatus
+<h3 id="cd.qdrant.io/v1beta2.HelmChartStatus">HelmChartStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#source.toolkit.fluxcd.io/v1beta2.HelmChart">HelmChart</a>)
+<a href="#cd.qdrant.io/v1beta2.HelmChart">HelmChart</a>)
 </p>
 <p>HelmChartStatus records the observed state of the HelmChart.</p>
 <div class="md-typeset__scrollwrap">
@@ -2712,11 +2712,11 @@ github.com/fluxcd/pkg/apis/meta.ReconcileRequestStatus
 </table>
 </div>
 </div>
-<h3 id="source.toolkit.fluxcd.io/v1beta2.HelmRepositorySpec">HelmRepositorySpec
+<h3 id="cd.qdrant.io/v1beta2.HelmRepositorySpec">HelmRepositorySpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#source.toolkit.fluxcd.io/v1beta2.HelmRepository">HelmRepository</a>)
+<a href="#cd.qdrant.io/v1beta2.HelmRepository">HelmRepository</a>)
 </p>
 <p>HelmRepositorySpec specifies the required configuration to produce an
 Artifact for a Helm repository index YAML.</p>
@@ -2911,11 +2911,11 @@ When not specified, defaults to &lsquo;generic&rsquo;.</p>
 </table>
 </div>
 </div>
-<h3 id="source.toolkit.fluxcd.io/v1beta2.HelmRepositoryStatus">HelmRepositoryStatus
+<h3 id="cd.qdrant.io/v1beta2.HelmRepositoryStatus">HelmRepositoryStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#source.toolkit.fluxcd.io/v1beta2.HelmRepository">HelmRepository</a>)
+<a href="#cd.qdrant.io/v1beta2.HelmRepository">HelmRepository</a>)
 </p>
 <p>HelmRepositoryStatus records the observed state of the HelmRepository.</p>
 <div class="md-typeset__scrollwrap">
@@ -3002,11 +3002,11 @@ github.com/fluxcd/pkg/apis/meta.ReconcileRequestStatus
 </table>
 </div>
 </div>
-<h3 id="source.toolkit.fluxcd.io/v1beta2.LocalHelmChartSourceReference">LocalHelmChartSourceReference
+<h3 id="cd.qdrant.io/v1beta2.LocalHelmChartSourceReference">LocalHelmChartSourceReference
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#source.toolkit.fluxcd.io/v1beta2.HelmChartSpec">HelmChartSpec</a>)
+<a href="#cd.qdrant.io/v1beta2.HelmChartSpec">HelmChartSpec</a>)
 </p>
 <p>LocalHelmChartSourceReference contains enough information to let you locate
 the typed referenced object at namespace level.</p>
@@ -3059,12 +3059,12 @@ string
 </table>
 </div>
 </div>
-<h3 id="source.toolkit.fluxcd.io/v1beta2.OCILayerSelector">OCILayerSelector
+<h3 id="cd.qdrant.io/v1beta2.OCILayerSelector">OCILayerSelector
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#source.toolkit.fluxcd.io/v1beta2.OCIRepositorySpec">OCIRepositorySpec</a>, 
-<a href="#source.toolkit.fluxcd.io/v1beta2.OCIRepositoryStatus">OCIRepositoryStatus</a>)
+<a href="#cd.qdrant.io/v1beta2.OCIRepositorySpec">OCIRepositorySpec</a>, 
+<a href="#cd.qdrant.io/v1beta2.OCIRepositoryStatus">OCIRepositoryStatus</a>)
 </p>
 <p>OCILayerSelector specifies which layer should be extracted from an OCI Artifact</p>
 <div class="md-typeset__scrollwrap">
@@ -3110,11 +3110,11 @@ is persisted to storage as it is.</p>
 </table>
 </div>
 </div>
-<h3 id="source.toolkit.fluxcd.io/v1beta2.OCIRepositoryRef">OCIRepositoryRef
+<h3 id="cd.qdrant.io/v1beta2.OCIRepositoryRef">OCIRepositoryRef
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#source.toolkit.fluxcd.io/v1beta2.OCIRepositorySpec">OCIRepositorySpec</a>)
+<a href="#cd.qdrant.io/v1beta2.OCIRepositorySpec">OCIRepositorySpec</a>)
 </p>
 <p>OCIRepositoryRef defines the image reference for the OCIRepository&rsquo;s URL</p>
 <div class="md-typeset__scrollwrap">
@@ -3181,11 +3181,11 @@ string
 </table>
 </div>
 </div>
-<h3 id="source.toolkit.fluxcd.io/v1beta2.OCIRepositorySpec">OCIRepositorySpec
+<h3 id="cd.qdrant.io/v1beta2.OCIRepositorySpec">OCIRepositorySpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#source.toolkit.fluxcd.io/v1beta2.OCIRepository">OCIRepository</a>)
+<a href="#cd.qdrant.io/v1beta2.OCIRepository">OCIRepository</a>)
 </p>
 <p>OCIRepositorySpec defines the desired state of OCIRepository</p>
 <div class="md-typeset__scrollwrap">
@@ -3214,7 +3214,7 @@ on a remote container registry.</p>
 <td>
 <code>ref</code><br>
 <em>
-<a href="#source.toolkit.fluxcd.io/v1beta2.OCIRepositoryRef">
+<a href="#cd.qdrant.io/v1beta2.OCIRepositoryRef">
 OCIRepositoryRef
 </a>
 </em>
@@ -3229,7 +3229,7 @@ defaults to the latest tag.</p>
 <td>
 <code>layerSelector</code><br>
 <em>
-<a href="#source.toolkit.fluxcd.io/v1beta2.OCILayerSelector">
+<a href="#cd.qdrant.io/v1beta2.OCILayerSelector">
 OCILayerSelector
 </a>
 </em>
@@ -3412,11 +3412,11 @@ bool
 </table>
 </div>
 </div>
-<h3 id="source.toolkit.fluxcd.io/v1beta2.OCIRepositoryStatus">OCIRepositoryStatus
+<h3 id="cd.qdrant.io/v1beta2.OCIRepositoryStatus">OCIRepositoryStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#source.toolkit.fluxcd.io/v1beta2.OCIRepository">OCIRepository</a>)
+<a href="#cd.qdrant.io/v1beta2.OCIRepository">OCIRepository</a>)
 </p>
 <p>OCIRepositoryStatus defines the observed state of OCIRepository</p>
 <div class="md-typeset__scrollwrap">
@@ -3519,7 +3519,7 @@ the source artifact.</p>
 <td>
 <code>observedLayerSelector</code><br>
 <em>
-<a href="#source.toolkit.fluxcd.io/v1beta2.OCILayerSelector">
+<a href="#cd.qdrant.io/v1beta2.OCILayerSelector">
 OCILayerSelector
 </a>
 </em>
@@ -3549,11 +3549,11 @@ github.com/fluxcd/pkg/apis/meta.ReconcileRequestStatus
 </table>
 </div>
 </div>
-<h3 id="source.toolkit.fluxcd.io/v1beta2.Source">Source
+<h3 id="cd.qdrant.io/v1beta2.Source">Source
 </h3>
 <p>Source interface must be supported by all API types.
 Source is the interface that provides generic access to the Artifact and
-interval. It must be supported by all kinds of the source.toolkit.fluxcd.io
+interval. It must be supported by all kinds of the cd.qdrant.io
 API group.</p>
 <p>Deprecated: use the Source interface from api/v1 instead. This type will be
 removed in a future release.</p>

--- a/docs/spec/v1/README.md
+++ b/docs/spec/v1/README.md
@@ -1,4 +1,4 @@
-# source.toolkit.fluxcd.io/v1
+# cd.qdrant.io/v1
 
 This is the v1 API specification for defining the desired state sources of Kubernetes clusters.
 

--- a/docs/spec/v1/gitrepositories.md
+++ b/docs/spec/v1/gitrepositories.md
@@ -13,7 +13,7 @@ resolved reference.
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1
+apiVersion: cd.qdrant.io/v1
 kind: GitRepository
 metadata:
   name: podinfo
@@ -252,7 +252,7 @@ To Git checkout a specified branch, use `.spec.ref.branch`:
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1
+apiVersion: cd.qdrant.io/v1
 kind: GitRepository
 metadata:
   name: <repository-name>
@@ -269,7 +269,7 @@ To Git checkout a specified tag, use `.spec.ref.tag`:
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1
+apiVersion: cd.qdrant.io/v1
 kind: GitRepository
 metadata:
   name: <repository-name>
@@ -288,7 +288,7 @@ use `.spec.ref.semver`:
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1
+apiVersion: cd.qdrant.io/v1
 kind: GitRepository
 metadata:
   name: <repository-name>
@@ -309,7 +309,7 @@ use `.spec.ref.name`:
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1
+apiVersion: cd.qdrant.io/v1
 kind: GitRepository
 metadata:
   name: <repository-name>
@@ -337,7 +337,7 @@ To Git checkout a specified commit, use `.spec.ref.commit`:
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1
+apiVersion: cd.qdrant.io/v1
 kind: GitRepository
 metadata:
   name: <repository-name>
@@ -352,7 +352,7 @@ commit must exist:
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1
+apiVersion: cd.qdrant.io/v1
 kind: GitRepository
 metadata:
   name: <repository-name>
@@ -383,7 +383,7 @@ signatures. The field offers two subfields:
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1
+apiVersion: cd.qdrant.io/v1
 kind: GitRepository
 metadata:
   name: podinfo
@@ -530,7 +530,7 @@ multiple benefits over regular submodules:
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1
+apiVersion: cd.qdrant.io/v1
 kind: GitRepository
 metadata:
   name: include-example
@@ -575,7 +575,7 @@ exclusions.
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1
+apiVersion: cd.qdrant.io/v1
 kind: GitRepository
 metadata:
   name: <repository-name>
@@ -632,7 +632,7 @@ In your YAML declaration:
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1
+apiVersion: cd.qdrant.io/v1
 kind: GitRepository
 metadata:
   name: <repository-name>
@@ -663,7 +663,7 @@ In your YAML declaration, comment out (or remove) the field:
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1
+apiVersion: cd.qdrant.io/v1
 kind: GitRepository
 metadata:
   name: <repository-name>
@@ -768,7 +768,7 @@ can be retrieved in-cluster from the `.status.artifact.url` HTTP address.
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1
+apiVersion: cd.qdrant.io/v1
 kind: GitRepository
 metadata:
   name: <repository-name>

--- a/docs/spec/v1/helmcharts.md
+++ b/docs/spec/v1/helmcharts.md
@@ -13,7 +13,7 @@ configuration:
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1
+apiVersion: cd.qdrant.io/v1
 kind: HelmChart
 metadata:
   name: podinfo
@@ -278,7 +278,7 @@ The `cosign` provider can be used to verify the signature of an OCI artifact usi
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1
+apiVersion: cd.qdrant.io/v1
 kind: HelmChart
 metadata:
   name: podinfo
@@ -340,7 +340,7 @@ Example of verifying  HelmCharts signed by the
 [Cosign GitHub Action](https://github.com/sigstore/cosign-installer) with GitHub OIDC Token:
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1
+apiVersion: cd.qdrant.io/v1
 kind: HelmChart
 metadata:
   name: podinfo
@@ -361,7 +361,7 @@ spec:
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1
+apiVersion: cd.qdrant.io/v1
 kind: HelmRepository
 metadata:
   name: podinfo
@@ -384,7 +384,7 @@ trust policy and CA certificate.
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1
+apiVersion: cd.qdrant.io/v1
 kind: HelmChart
 metadata:
   name: podinfo
@@ -464,7 +464,7 @@ In your YAML declaration:
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1
+apiVersion: cd.qdrant.io/v1
 kind: HelmChart
 metadata:
   name: <chart-name>
@@ -489,7 +489,7 @@ In your YAML declaration, comment out (or remove) the field:
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1
+apiVersion: cd.qdrant.io/v1
 kind: HelmChart
 metadata:
   name: <chart-name>
@@ -637,7 +637,7 @@ and can be retrieved in-cluster from the `.status.artifact.url` HTTP address.
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1
+apiVersion: cd.qdrant.io/v1
 kind: HelmChart
 metadata:
   name: <chart-name>
@@ -659,7 +659,7 @@ with the `HelmChart` object generation. For example, if the chart version is
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1
+apiVersion: cd.qdrant.io/v1
 kind: HelmChart
 metadata:
   name: <chart-name>
@@ -684,7 +684,7 @@ the `status.artifact.revision` value will be `6.0.3+4e5cbb7b97d0`.
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1
+apiVersion: cd.qdrant.io/v1
 kind: HelmChart
 metadata:
   name: <chart-name>

--- a/docs/spec/v1/helmrepositories.md
+++ b/docs/spec/v1/helmrepositories.md
@@ -19,7 +19,7 @@ repository](https://github.com/stefanprodan/podinfo)):
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1
+apiVersion: cd.qdrant.io/v1
 kind: HelmRepository
 metadata:
   name: podinfo
@@ -98,7 +98,7 @@ The following is an example of an OCI HelmRepository.
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1
+apiVersion: cd.qdrant.io/v1
 kind: HelmRepository
 metadata:
   name: podinfo
@@ -376,7 +376,7 @@ For example:
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1
+apiVersion: cd.qdrant.io/v1
 kind: HelmRepository
 metadata:
   name: example
@@ -401,7 +401,7 @@ OCI Helm repository example:
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1
+apiVersion: cd.qdrant.io/v1
 kind: HelmRepository
 metadata:
   name: podinfo
@@ -467,7 +467,7 @@ Example usage:
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1
+apiVersion: cd.qdrant.io/v1
 kind: HelmRepository
 metadata:
   name: example
@@ -564,7 +564,7 @@ In your YAML declaration:
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1
+apiVersion: cd.qdrant.io/v1
 kind: HelmRepository
 metadata:
   name: <repository-name>
@@ -595,7 +595,7 @@ In your YAML declaration, comment out (or remove) the field:
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1
+apiVersion: cd.qdrant.io/v1
 kind: HelmRepository
 metadata:
   name: <repository-name>
@@ -708,7 +708,7 @@ The Artifact file is an exact copy of the Helm repository index YAML
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1
+apiVersion: cd.qdrant.io/v1
 kind: HelmRepository
 metadata:
   name: <repository-name>

--- a/docs/spec/v1alpha1/README.md
+++ b/docs/spec/v1alpha1/README.md
@@ -1,4 +1,4 @@
-# source.toolkit.fluxcd.io/v1alpha1
+# cd.qdrant.io/v1alpha1
 
 This is the v1alpha1 API specification for defining the desired state sources of Kubernetes clusters.
 

--- a/docs/spec/v1alpha1/buckets.md
+++ b/docs/spec/v1alpha1/buckets.md
@@ -117,7 +117,7 @@ entries may overrule default exclusions.
 Another option is to use the `spec.ignore` field, for example:
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1alpha1
+apiVersion: cd.qdrant.io/v1alpha1
 kind: Bucket
 metadata:
   name: podinfo
@@ -142,7 +142,7 @@ Authentication credentials can be provided with a Kubernetes secret that contain
 `accesskey` and `secretkey` fields:
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1alpha1
+apiVersion: cd.qdrant.io/v1alpha1
 kind: Bucket
 metadata:
   name: podinfo

--- a/docs/spec/v1alpha1/gitrepositories.md
+++ b/docs/spec/v1alpha1/gitrepositories.md
@@ -140,7 +140,7 @@ entries may overrule default exclusions.
 Another option is to use the `spec.ignore` field, for example:
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1alpha1
+apiVersion: cd.qdrant.io/v1alpha1
 kind: GitRepository
 metadata:
   name: podinfo
@@ -166,7 +166,7 @@ When specified, `spec.ignore` overrides the default exclusion list.
 Pull the master branch of a public repository every minute:
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1alpha1
+apiVersion: cd.qdrant.io/v1alpha1
 kind: GitRepository
 metadata:
   name: podinfo
@@ -178,7 +178,7 @@ spec:
 Pull a specific branch:
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1alpha1
+apiVersion: cd.qdrant.io/v1alpha1
 kind: GitRepository
 metadata:
   name: podinfo
@@ -192,7 +192,7 @@ spec:
 Checkout a specific commit from a branch:
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1alpha1
+apiVersion: cd.qdrant.io/v1alpha1
 kind: GitRepository
 metadata:
   name: podinfo
@@ -207,7 +207,7 @@ spec:
 Pull a specific tag:
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1alpha1
+apiVersion: cd.qdrant.io/v1alpha1
 kind: GitRepository
 metadata:
   name: podinfo
@@ -221,7 +221,7 @@ spec:
 Pull tag based on a [semver range](https://github.com/blang/semver#ranges):
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1alpha1
+apiVersion: cd.qdrant.io/v1alpha1
 kind: GitRepository
 metadata:
   name: podinfo
@@ -237,7 +237,7 @@ spec:
 HTTPS authentication requires a Kubernetes secret with `username` and `password` fields:
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1alpha1
+apiVersion: cd.qdrant.io/v1alpha1
 kind: GitRepository
 metadata:
   name: podinfo
@@ -264,7 +264,7 @@ data:
 SSH authentication requires a Kubernetes secret with `identity` and `known_hosts` fields:
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1alpha1
+apiVersion: cd.qdrant.io/v1alpha1
 kind: GitRepository
 metadata:
   name: podinfo
@@ -305,7 +305,7 @@ kubectl create secret generic ssh-credentials \
 Verify the OpenPGP signature for the commit that master branch HEAD points to:
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1alpha1
+apiVersion: cd.qdrant.io/v1alpha1
 kind: GitRepository
 metadata:
   name: podinfo

--- a/docs/spec/v1alpha1/helmcharts.md
+++ b/docs/spec/v1alpha1/helmcharts.md
@@ -102,7 +102,7 @@ const (
 Pull a specific chart version every five minutes:
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1alpha1
+apiVersion: cd.qdrant.io/v1alpha1
 kind: HelmChart
 metadata:
   name: redis
@@ -118,7 +118,7 @@ spec:
 Pull the latest chart version that matches the semver range every ten minutes:
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1alpha1
+apiVersion: cd.qdrant.io/v1alpha1
 kind: HelmChart
 metadata:
   name: redis
@@ -135,7 +135,7 @@ Check a Git repository every ten minutes for a new `version` in the
 `Chart.yaml`, and package a new chart if the revision differs:
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1alpha1
+apiVersion: cd.qdrant.io/v1alpha1
 kind: HelmChart
 metadata:
   name: podinfo
@@ -151,7 +151,7 @@ Check a S3 compatible bucket every ten minutes for a new `version` in the
 `Chart.yaml`, and package a new chart if the revision differs:
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1alpha1
+apiVersion: cd.qdrant.io/v1alpha1
 kind: HelmChart
 metadata:
   name: podinfo

--- a/docs/spec/v1alpha1/helmrepositories.md
+++ b/docs/spec/v1alpha1/helmrepositories.md
@@ -71,7 +71,7 @@ const (
 Pull the index of a public Helm repository every ten minutes:
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1alpha1
+apiVersion: cd.qdrant.io/v1alpha1
 kind: HelmRepository
 metadata:
   name: stable
@@ -83,7 +83,7 @@ spec:
 Pull the index of a private Helm repository every minute:
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1alpha1
+apiVersion: cd.qdrant.io/v1alpha1
 kind: HelmRepository
 metadata:
   name: private

--- a/docs/spec/v1beta1/README.md
+++ b/docs/spec/v1beta1/README.md
@@ -1,4 +1,4 @@
-# source.toolkit.fluxcd.io/v1beta1
+# cd.qdrant.io/v1beta1
 
 This is the v1beta1 API specification for defining the desired state sources of Kubernetes clusters.
 

--- a/docs/spec/v1beta1/buckets.md
+++ b/docs/spec/v1beta1/buckets.md
@@ -132,7 +132,7 @@ entries may overrule default exclusions.
 Another option is to use the `spec.ignore` field, for example:
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: cd.qdrant.io/v1beta1
 kind: Bucket
 metadata:
   name: podinfo
@@ -158,7 +158,7 @@ Authentication credentials can be provided with a Kubernetes secret that contain
 `accesskey` and `secretkey` fields:
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: cd.qdrant.io/v1beta1
 kind: Bucket
 metadata:
   name: podinfo
@@ -193,7 +193,7 @@ When the provider is `aws` and the `secretRef` is not specified,
 the credentials are retrieve from the EC2 service:
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: cd.qdrant.io/v1beta1
 kind: Bucket
 metadata:
   name: podinfo

--- a/docs/spec/v1beta1/gitrepositories.md
+++ b/docs/spec/v1beta1/gitrepositories.md
@@ -169,7 +169,7 @@ entries may overrule default exclusions.
 Another option is to use the `spec.ignore` field, for example:
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: cd.qdrant.io/v1beta1
 kind: GitRepository
 metadata:
   name: podinfo
@@ -214,7 +214,7 @@ option to select the git library while accepting the drawbacks.
 Pull the master branch from a repository in Azure DevOps.
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: cd.qdrant.io/v1beta1
 kind: GitRepository
 metadata:
   name: podinfo
@@ -247,7 +247,7 @@ libgit2 v1.1.1 at the moment.
 Pull the master branch of a public repository every minute:
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: cd.qdrant.io/v1beta1
 kind: GitRepository
 metadata:
   name: podinfo
@@ -260,7 +260,7 @@ spec:
 Pull a specific branch:
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: cd.qdrant.io/v1beta1
 kind: GitRepository
 metadata:
   name: podinfo
@@ -275,7 +275,7 @@ spec:
 Checkout a specific commit from a branch:
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: cd.qdrant.io/v1beta1
 kind: GitRepository
 metadata:
   name: podinfo
@@ -291,7 +291,7 @@ spec:
 Checkout a specific commit:
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: cd.qdrant.io/v1beta1
 kind: GitRepository
 metadata:
   name: podinfo
@@ -306,7 +306,7 @@ spec:
 Pull a specific tag:
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: cd.qdrant.io/v1beta1
 kind: GitRepository
 metadata:
   name: podinfo
@@ -321,7 +321,7 @@ spec:
 Pull tag based on a [semver range](https://github.com/Masterminds/semver#checking-version-constraints):
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: cd.qdrant.io/v1beta1
 kind: GitRepository
 metadata:
   name: podinfo
@@ -338,7 +338,7 @@ spec:
 HTTPS authentication requires a Kubernetes secret with `username` and `password` fields:
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: cd.qdrant.io/v1beta1
 kind: GitRepository
 metadata:
   name: podinfo
@@ -365,7 +365,7 @@ data:
 Cloning over HTTPS from a Git repository with a self-signed certificate:
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: cd.qdrant.io/v1beta1
 kind: GitRepository
 metadata:
   name: podinfo
@@ -396,7 +396,7 @@ can be omitted.
 SSH authentication requires a Kubernetes secret with `identity` and `known_hosts` fields:
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: cd.qdrant.io/v1beta1
 kind: GitRepository
 metadata:
   name: podinfo
@@ -450,7 +450,7 @@ kubectl create secret generic ssh-credentials \
 Verify the OpenPGP signature for the commit that master branch HEAD points to:
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: cd.qdrant.io/v1beta1
 kind: GitRepository
 metadata:
   name: podinfo
@@ -493,7 +493,7 @@ With `spec.recurseSubmodules` you can configure the controller to
 clone a specific branch including its Git submodules:
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: cd.qdrant.io/v1beta1
 kind: GitRepository
 metadata:
   name: repo-with-submodules
@@ -534,7 +534,7 @@ regular submodules:
 * Multiple `GitRepositories` could include the same repository, which decreases the amount of cloning done compared to using submodules.
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: cd.qdrant.io/v1beta1
 kind: GitRepository
 metadata:
   name: app-repo
@@ -547,7 +547,7 @@ spec:
   ref:
     branch: main
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: cd.qdrant.io/v1beta1
 kind: GitRepository
 metadata:
   name: config-repo

--- a/docs/spec/v1beta1/helmcharts.md
+++ b/docs/spec/v1beta1/helmcharts.md
@@ -147,7 +147,7 @@ const (
 Pull a specific chart version every five minutes:
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: cd.qdrant.io/v1beta1
 kind: HelmChart
 metadata:
   name: redis
@@ -165,7 +165,7 @@ Pull the latest chart version that matches the [semver range](https://github.com
 every ten minutes:
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: cd.qdrant.io/v1beta1
 kind: HelmChart
 metadata:
   name: redis
@@ -183,7 +183,7 @@ Check a Git repository every ten minutes for a new `version` in the
 `Chart.yaml`, and package a new chart if the revision differs:
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: cd.qdrant.io/v1beta1
 kind: HelmChart
 metadata:
   name: podinfo
@@ -200,7 +200,7 @@ Check a S3 compatible bucket every ten minutes for a new `version` in the
 `Chart.yaml`, and package a new chart if the revision differs:
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: cd.qdrant.io/v1beta1
 kind: HelmChart
 metadata:
   name: podinfo
@@ -217,7 +217,7 @@ Override default values with alternative values files relative to the
 path in the SourceRef:
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: cd.qdrant.io/v1beta1
 kind: HelmChart
 metadata:
   name: redis
@@ -235,7 +235,7 @@ spec:
 ```
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: cd.qdrant.io/v1beta1
 kind: HelmChart
 metadata:
   name: podinfo
@@ -254,7 +254,7 @@ spec:
 Reconcile with every change to the source revision:
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: cd.qdrant.io/v1beta1
 kind: HelmChart
 metadata:
   name: podinfo

--- a/docs/spec/v1beta1/helmrepositories.md
+++ b/docs/spec/v1beta1/helmrepositories.md
@@ -94,7 +94,7 @@ const (
 Pull the index of a public Helm repository every ten minutes:
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: cd.qdrant.io/v1beta1
 kind: HelmRepository
 metadata:
   name: stable
@@ -107,7 +107,7 @@ spec:
 Pull the index of a private Helm repository every minute:
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: cd.qdrant.io/v1beta1
 kind: HelmRepository
 metadata:
   name: private

--- a/docs/spec/v1beta2/README.md
+++ b/docs/spec/v1beta2/README.md
@@ -1,4 +1,4 @@
-# source.toolkit.fluxcd.io/v1beta2
+# cd.qdrant.io/v1beta2
 
 This is the v1beta2 API specification for defining the desired state sources of Kubernetes clusters.
 

--- a/docs/spec/v1beta2/buckets.md
+++ b/docs/spec/v1beta2/buckets.md
@@ -14,7 +14,7 @@ compatible API (e.g. [Minio](https://min.io)):
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: Bucket
 metadata:
   name: minio-bucket
@@ -155,7 +155,7 @@ The Provider allows for specifying a region the bucket is in using the
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: Bucket
 metadata:
   name: generic-insecure
@@ -203,7 +203,7 @@ the source-controller service account that grants access to the bucket.
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: Bucket
 metadata:
   name: aws
@@ -245,7 +245,7 @@ Replace `<bucket-name>` with the specified `.spec.bucketName`.
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: Bucket
 metadata:
   name: aws
@@ -309,7 +309,7 @@ the base URL can be configured using `.data.authorityHost`. If not supplied,
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: Bucket
 metadata:
   name: azure-public
@@ -326,7 +326,7 @@ spec:
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: Bucket
 metadata:
   name: azure-service-principal-secret
@@ -355,7 +355,7 @@ data:
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: Bucket
 metadata:
   name: azure-service-principal-cert
@@ -387,7 +387,7 @@ data:
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: Bucket
 metadata:
   name: azure-managed-identity
@@ -414,7 +414,7 @@ data:
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: Bucket
 metadata:
   name: azure-shared-key
@@ -505,7 +505,7 @@ Deployment and ServiceAccount, then you don't need to reference a Secret. For mo
 please see [documentation](https://azure.github.io/azure-workload-identity/docs/quick-start.html).
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: Bucket
 metadata:
   name: azure-bucket
@@ -580,7 +580,7 @@ If you have set up aad-pod-identity correctly and labeled the source-controller
 Deployment, then you don't need to reference a Secret.
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: Bucket
 metadata:
   name: azure-bucket
@@ -596,7 +596,7 @@ spec:
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: Bucket
 metadata:
   name: azure-sas-token
@@ -663,7 +663,7 @@ The Provider allows for specifying the
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: Bucket
 metadata:
   name: gcp-workload-identity
@@ -681,7 +681,7 @@ spec:
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: Bucket
 metadata:
   name: gcp-secret
@@ -816,7 +816,7 @@ Example usage:
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: Bucket
 metadata:
   name: example
@@ -951,7 +951,7 @@ file exclusions.
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: Bucket
 metadata:
   name: <bucket-name>
@@ -1008,7 +1008,7 @@ In your YAML declaration:
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: Bucket
 metadata:
   name: <bucket-name>
@@ -1039,7 +1039,7 @@ In your YAML declaration, comment out (or remove) the field:
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: Bucket
 metadata:
   name: <bucket-name>
@@ -1144,7 +1144,7 @@ The Artifact file is a gzip compressed TAR archive
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: Bucket
 metadata:
   name: <bucket-name>

--- a/docs/spec/v1beta2/gitrepositories.md
+++ b/docs/spec/v1beta2/gitrepositories.md
@@ -13,7 +13,7 @@ resolved reference.
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: GitRepository
 metadata:
   name: podinfo
@@ -247,7 +247,7 @@ To Git checkout a specified branch, use `.spec.ref.branch`:
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: GitRepository
 metadata:
   name: <repository-name>
@@ -264,7 +264,7 @@ To Git checkout a specified tag, use `.spec.ref.tag`:
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: GitRepository
 metadata:
   name: <repository-name>
@@ -283,7 +283,7 @@ use `.spec.ref.semver`:
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: GitRepository
 metadata:
   name: <repository-name>
@@ -304,7 +304,7 @@ use `.spec.ref.name`:
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: GitRepository
 metadata:
   name: <repository-name>
@@ -326,7 +326,7 @@ To Git checkout a specified commit, use `.spec.ref.commit`:
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: GitRepository
 metadata:
   name: <repository-name>
@@ -341,7 +341,7 @@ commit must exist:
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: GitRepository
 metadata:
   name: <repository-name>
@@ -363,7 +363,7 @@ signatures. The field offers two subfields:
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: cd.qdrant.io/v1beta1
 kind: GitRepository
 metadata:
   name: podinfo
@@ -489,7 +489,7 @@ multiple benefits over regular submodules:
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: GitRepository
 metadata:
   name: include-example
@@ -534,7 +534,7 @@ exclusions.
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: GitRepository
 metadata:
   name: <repository-name>
@@ -591,7 +591,7 @@ In your YAML declaration:
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: GitRepository
 metadata:
   name: <repository-name>
@@ -622,7 +622,7 @@ In your YAML declaration, comment out (or remove) the field:
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: GitRepository
 metadata:
   name: <repository-name>
@@ -728,7 +728,7 @@ can be retrieved in-cluster from the `.status.artifact.url` HTTP address.
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: GitRepository
 metadata:
   name: <repository-name>

--- a/docs/spec/v1beta2/helmcharts.md
+++ b/docs/spec/v1beta2/helmcharts.md
@@ -13,7 +13,7 @@ configuration:
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: HelmChart
 metadata:
   name: podinfo
@@ -278,7 +278,7 @@ The `cosign` provider can be used to verify the signature of an OCI artifact usi
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: HelmChart
 metadata:
   name: podinfo
@@ -340,7 +340,7 @@ Example of verifying  HelmCharts signed by the
 [Cosign GitHub Action](https://github.com/sigstore/cosign-installer) with GitHub OIDC Token:
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: HelmChart
 metadata:
   name: podinfo
@@ -361,7 +361,7 @@ spec:
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: HelmRepository
 metadata:
   name: podinfo
@@ -384,7 +384,7 @@ trust policy and CA certificate.
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: HelmChart
 metadata:
   name: podinfo
@@ -464,7 +464,7 @@ In your YAML declaration:
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: HelmChart
 metadata:
   name: <chart-name>
@@ -489,7 +489,7 @@ In your YAML declaration, comment out (or remove) the field:
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: HelmChart
 metadata:
   name: <chart-name>
@@ -637,7 +637,7 @@ and can be retrieved in-cluster from the `.status.artifact.url` HTTP address.
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: HelmChart
 metadata:
   name: <chart-name>
@@ -659,7 +659,7 @@ with the `HelmChart` object generation. For example, if the chart version is
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: HelmChart
 metadata:
   name: <chart-name>
@@ -684,7 +684,7 @@ the `status.artifact.revision` value will be `6.0.3+4e5cbb7b97d0`.
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: HelmChart
 metadata:
   name: <chart-name>

--- a/docs/spec/v1beta2/helmrepositories.md
+++ b/docs/spec/v1beta2/helmrepositories.md
@@ -19,7 +19,7 @@ repository](https://github.com/stefanprodan/podinfo)):
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: HelmRepository
 metadata:
   name: podinfo
@@ -98,7 +98,7 @@ The following is an example of an OCI HelmRepository.
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: HelmRepository
 metadata:
   name: podinfo
@@ -412,7 +412,7 @@ For example:
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: HelmRepository
 metadata:
   name: example
@@ -437,7 +437,7 @@ OCI Helm repository example:
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: HelmRepository
 metadata:
   name: podinfo
@@ -503,7 +503,7 @@ Example usage:
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: HelmRepository
 metadata:
   name: example
@@ -600,7 +600,7 @@ In your YAML declaration:
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: HelmRepository
 metadata:
   name: <repository-name>
@@ -631,7 +631,7 @@ In your YAML declaration, comment out (or remove) the field:
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: HelmRepository
 metadata:
   name: <repository-name>
@@ -744,7 +744,7 @@ The Artifact file is an exact copy of the Helm repository index YAML
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: HelmRepository
 metadata:
   name: <repository-name>

--- a/docs/spec/v1beta2/ocirepositories.md
+++ b/docs/spec/v1beta2/ocirepositories.md
@@ -13,7 +13,7 @@ resolved digest.
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: OCIRepository
 metadata:
   name: podinfo
@@ -302,7 +302,7 @@ Example usage:
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: OCIRepository
 metadata:
   name: example
@@ -417,7 +417,7 @@ To pull a specific tag, use `.spec.ref.tag`:
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: OCIRepository
 metadata:
   name: <repository-name>
@@ -434,7 +434,7 @@ use `.spec.ref.semver`:
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: OCIRepository
 metadata:
   name: <repository-name>
@@ -458,7 +458,7 @@ is set.
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: OCIRepository
 metadata:
   name: podinfo
@@ -483,7 +483,7 @@ To pull a specific digest, use `.spec.ref.digest`:
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: OCIRepository
 metadata:
   name: <repository-name>
@@ -504,7 +504,7 @@ To extract a layer matching a specific
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: OCIRepository
 metadata:
   name: <repository-name>
@@ -556,7 +556,7 @@ or via the [Cosign Keyless](https://github.com/sigstore/cosign/blob/main/KEYLESS
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: OCIRepository
 metadata:
   name: <repository-name>
@@ -618,7 +618,7 @@ Example of verifying artifacts signed by the
 [Cosign GitHub Action](https://github.com/sigstore/cosign-installer) with GitHub OIDC Token:
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: OCIRepository
 metadata:
   name: podinfo
@@ -645,7 +645,7 @@ trust policy and CA certificate.
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: OCIRepository
 metadata:
   name: <repository-name>
@@ -706,7 +706,7 @@ the [`.spec.ignore` field](#ignore).
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: OCIRepository
 metadata:
   name: <repository-name>
@@ -773,7 +773,7 @@ In your YAML declaration:
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: OCIRepository
 metadata:
   name: <repository-name>
@@ -804,7 +804,7 @@ In your YAML declaration, comment out (or remove) the field:
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: OCIRepository
 metadata:
   name: <repository-name>
@@ -919,7 +919,7 @@ can be retrieved in-cluster from the `.status.artifact.url` HTTP address.
 #### Artifact example
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: cd.qdrant.io/v1beta2
 kind: OCIRepository
 metadata:
   name: <repository-name>

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,12 @@ module github.com/fluxcd/source-controller
 
 go 1.22.5
 
-replace github.com/fluxcd/source-controller/api => ./api
+replace (
+	github.com/fluxcd/source-controller/api => ./api
+	github.com/fluxcd/source-controller/internal => ./internal
+	github.com/fluxcd/source-controller/pkg => ./pkg
+	github.com/fluxcd/source-controller/test => ./test
+)
 
 // Replace digest lib to master to gather access to BLAKE3.
 // xref: https://github.com/opencontainers/go-digest/pull/66
@@ -11,7 +16,6 @@ replace github.com/opencontainers/go-digest => github.com/opencontainers/go-dige
 require (
 	cloud.google.com/go/compute/metadata v0.5.0
 	cloud.google.com/go/storage v1.41.0
-	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.13.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.7.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.4.0
@@ -82,6 +86,7 @@ require (
 	cloud.google.com/go/iam v1.1.12 // indirect
 	dario.cat/mergo v1.0.0 // indirect
 	filippo.io/edwards25519 v1.1.0 // indirect
+	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24 // indirect
 	github.com/AliyunContainerService/ack-ram-tool/pkg/credentials/alibabacloudsdkgo/helper v0.2.0 // indirect
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0 // indirect

--- a/internal/controller/bucket_controller.go
+++ b/internal/controller/bucket_controller.go
@@ -113,9 +113,9 @@ var bucketFailConditions = []string{
 	sourcev1.StorageOperationFailedCondition,
 }
 
-// +kubebuilder:rbac:groups=source.toolkit.fluxcd.io,resources=buckets,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=source.toolkit.fluxcd.io,resources=buckets/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=source.toolkit.fluxcd.io,resources=buckets/finalizers,verbs=get;create;update;patch;delete
+// +kubebuilder:rbac:groups=cd.qdrant.io,resources=buckets,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=cd.qdrant.io,resources=buckets/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=cd.qdrant.io,resources=buckets/finalizers,verbs=get;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 
 // BucketReconciler reconciles a v1beta2.Bucket object.

--- a/internal/controller/bucket_controller.go
+++ b/internal/controller/bucket_controller.go
@@ -126,6 +126,7 @@ type BucketReconciler struct {
 
 	Storage        *Storage
 	ControllerName string
+	LeaderElection *bool
 
 	patchOptions []patch.Option
 }
@@ -172,7 +173,8 @@ func (r *BucketReconciler) SetupWithManagerAndOptions(mgr ctrl.Manager, opts Buc
 		For(&bucketv1.Bucket{}).
 		WithEventFilter(predicate.Or(predicate.GenerationChangedPredicate{}, predicates.ReconcileRequestedPredicate{})).
 		WithOptions(controller.Options{
-			RateLimiter: opts.RateLimiter,
+			RateLimiter:        opts.RateLimiter,
+			NeedLeaderElection: r.LeaderElection,
 		}).
 		Complete(r)
 }

--- a/internal/controller/gitrepository_controller.go
+++ b/internal/controller/gitrepository_controller.go
@@ -129,6 +129,7 @@ type GitRepositoryReconciler struct {
 
 	Storage        *Storage
 	ControllerName string
+	LeaderElection *bool
 
 	requeueDependency time.Duration
 	features          map[string]bool
@@ -163,7 +164,8 @@ func (r *GitRepositoryReconciler) SetupWithManagerAndOptions(mgr ctrl.Manager, o
 			predicate.Or(predicate.GenerationChangedPredicate{}, predicates.ReconcileRequestedPredicate{}),
 		)).
 		WithOptions(controller.Options{
-			RateLimiter: opts.RateLimiter,
+			RateLimiter:        opts.RateLimiter,
+			NeedLeaderElection: r.LeaderElection,
 		}).
 		Complete(r)
 }

--- a/internal/controller/gitrepository_controller.go
+++ b/internal/controller/gitrepository_controller.go
@@ -116,9 +116,9 @@ func getPatchOptions(ownedConditions []string, controllerName string) []patch.Op
 	}
 }
 
-// +kubebuilder:rbac:groups=source.toolkit.fluxcd.io,resources=gitrepositories,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=source.toolkit.fluxcd.io,resources=gitrepositories/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=source.toolkit.fluxcd.io,resources=gitrepositories/finalizers,verbs=get;create;update;patch;delete
+// +kubebuilder:rbac:groups=cd.qdrant.io,resources=gitrepositories,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=cd.qdrant.io,resources=gitrepositories/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=cd.qdrant.io,resources=gitrepositories/finalizers,verbs=get;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
 // GitRepositoryReconciler reconciles a v1beta2.GitRepository object.

--- a/internal/controller/gitrepository_controller_fuzz_test.go
+++ b/internal/controller/gitrepository_controller_fuzz_test.go
@@ -1,534 +1,534 @@
-//go:build gofuzz_libfuzzer
-// +build gofuzz_libfuzzer
-
-/*
-Copyright 2022 The Flux authors
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
+// //go:build gofuzz_libfuzzer
+// // +build gofuzz_libfuzzer
+//
+// /*
+// Copyright 2022 The Flux authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// */
 package controller
 
-import (
-	"context"
-	"crypto/tls"
-	"crypto/x509"
-	"embed"
-	"errors"
-	"fmt"
-	"io/fs"
-	"net/http"
-	"net/url"
-	"os"
-	"os/exec"
-	"path"
-	"path/filepath"
-	"strings"
-	"sync"
-	"testing"
-	"time"
-
-	fuzz "github.com/AdaLogics/go-fuzz-headers"
-	"github.com/go-git/go-billy/v5"
-	"github.com/go-git/go-billy/v5/memfs"
-	"github.com/go-git/go-git/v5"
-	"github.com/go-git/go-git/v5/config"
-	"github.com/go-git/go-git/v5/plumbing"
-	"github.com/go-git/go-git/v5/plumbing/object"
-	gitclient "github.com/go-git/go-git/v5/plumbing/transport/client"
-	httptransport "github.com/go-git/go-git/v5/plumbing/transport/http"
-	"github.com/go-git/go-git/v5/storage/memory"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
-
-	"github.com/fluxcd/pkg/gittestserver"
-	"github.com/fluxcd/pkg/runtime/controller"
-	"github.com/fluxcd/pkg/runtime/testenv"
-
-	sourcev1 "github.com/fluxcd/source-controller/api/v1"
-)
-
-var (
-	noOfCreatedFiles = 0
-	interval         = time.Millisecond * 10
-	indexInterval    = time.Millisecond * 10
-	pullInterval     = time.Second * 3
-	initter          sync.Once
-	gitServer        *gittestserver.GitServer
-	k8sClient        client.Client
-	cfg              *rest.Config
-	testEnv          *testenv.Environment
-
-	storage *Storage
-
-	examplePublicKey  []byte
-	examplePrivateKey []byte
-	exampleCA         []byte
-)
-
-//go:embed testdata/crd/*.yaml
-//go:embed testdata/certs/*
-var testFiles embed.FS
-
-const (
-	defaultBinVersion     = "1.24"
-	lettersAndNumbers     = "abcdefghijklmnopqrstuvwxyz123456789"
-	lettersNumbersAndDash = "abcdefghijklmnopqrstuvwxyz123456789-"
-)
-
-// FuzzRandomGitFiles implements a fuzzer that
-// targets the GitRepository reconciler.
-func FuzzRandomGitFiles(f *testing.F) {
-	f.Fuzz(func(t *testing.T, data []byte) {
-		initter.Do(func() {
-			utilruntime.Must(ensureDependencies())
-		})
-
-		f := fuzz.NewConsumer(data)
-		namespace, deleteNamespace, err := createNamespace(f)
-		if err != nil {
-			return
-		}
-		defer deleteNamespace()
-
-		gitServerURL, stopGitServer := createGitServer(f)
-		defer stopGitServer()
-
-		fs := memfs.New()
-		gitrepo, err := git.Init(memory.NewStorage(), fs)
-		if err != nil {
-			panic(err)
-		}
-		wt, err := gitrepo.Worktree()
-		if err != nil {
-			panic(err)
-		}
-
-		// Create random files for the git source
-		err = createRandomFiles(f, fs, wt)
-		if err != nil {
-			return
-		}
-
-		commit, err := pushFilesToGit(gitrepo, wt, gitServerURL.String())
-		if err != nil {
-			return
-		}
-		created, err := createGitRepository(f, gitServerURL.String(), commit.String(), namespace.Name)
-		if err != nil {
-			return
-		}
-		err = k8sClient.Create(context.Background(), created)
-		if err != nil {
-			return
-		}
-		defer k8sClient.Delete(context.Background(), created)
-
-		// Let the reconciler do its thing:
-		time.Sleep(60 * time.Millisecond)
-	})
-}
-
-// FuzzGitResourceObject implements a fuzzer that targets
-// the GitRepository reconciler.
-func FuzzGitResourceObject(f *testing.F) {
-	f.Fuzz(func(t *testing.T, data []byte) {
-		initter.Do(func() {
-			utilruntime.Must(ensureDependencies())
-		})
-
-		f := fuzz.NewConsumer(data)
-
-		// Create this early because if it fails, then the fuzzer
-		// does not need to proceed.
-		repository := &sourcev1.GitRepository{}
-		err := f.GenerateStruct(repository)
-		if err != nil {
-			return
-		}
-
-		metaName, err := f.GetStringFrom(lettersNumbersAndDash, 59)
-		if err != nil {
-			return
-		}
-
-		gitServerURL, stopGitServer := createGitServer(f)
-		defer stopGitServer()
-
-		fs := memfs.New()
-		gitrepo, err := git.Init(memory.NewStorage(), fs)
-		if err != nil {
-			return
-		}
-		wt, err := gitrepo.Worktree()
-		if err != nil {
-			return
-		}
-
-		// Add a file
-		ff, _ := fs.Create("fixture")
-		_ = ff.Close()
-		_, err = wt.Add(fs.Join("fixture"))
-		if err != nil {
-			return
-		}
-
-		commit, err := pushFilesToGit(gitrepo, wt, gitServerURL.String())
-		if err != nil {
-			return
-		}
-
-		namespace, deleteNamespace, err := createNamespace(f)
-		if err != nil {
-			return
-		}
-		defer deleteNamespace()
-
-		repository.Spec.URL = gitServerURL.String()
-		repository.Spec.Verification.Mode = "head"
-		repository.Spec.SecretRef = nil
-
-		reference := &sourcev1.GitRepositoryRef{Branch: "some-branch"}
-		reference.Commit = strings.Replace(reference.Commit, "<commit>", commit.String(), 1)
-		repository.Spec.Reference = reference
-
-		repository.ObjectMeta = metav1.ObjectMeta{
-			Name:      metaName,
-			Namespace: namespace.Name,
-		}
-		err = k8sClient.Create(context.Background(), repository)
-		if err != nil {
-			return
-		}
-		defer k8sClient.Delete(context.Background(), repository)
-
-		// Let the reconciler do its thing.
-		time.Sleep(50 * time.Millisecond)
-	})
-}
-
-func loadExampleKeys() (err error) {
-	examplePublicKey, err = os.ReadFile("testdata/certs/server.pem")
-	if err != nil {
-		return err
-	}
-	examplePrivateKey, err = os.ReadFile("testdata/certs/server-key.pem")
-	if err != nil {
-		return err
-	}
-	exampleCA, err = os.ReadFile("testdata/certs/ca.pem")
-	return err
-}
-
-// createGitRepository is a helper function to create GitRepository objects.
-func createGitRepository(f *fuzz.ConsumeFuzzer, specUrl, commit, namespaceName string) (*sourcev1.GitRepository, error) {
-	reference := &sourcev1.GitRepositoryRef{Branch: "some-branch"}
-	reference.Commit = strings.Replace(reference.Commit, "<commit>", commit, 1)
-	nnID, err := f.GetStringFrom(lettersAndNumbers, 10)
-	if err != nil {
-		return &sourcev1.GitRepository{}, err
-	}
-	key := types.NamespacedName{
-		Name:      fmt.Sprintf("git-ref-test-%s", nnID),
-		Namespace: namespaceName,
-	}
-
-	return &sourcev1.GitRepository{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      key.Name,
-			Namespace: key.Namespace,
-		},
-		Spec: sourcev1.GitRepositorySpec{
-			URL:       specUrl,
-			Interval:  metav1.Duration{Duration: indexInterval},
-			Reference: reference,
-		},
-	}, nil
-}
-
-// createNamespace is a helper function to create kubernetes namespaces.
-func createNamespace(f *fuzz.ConsumeFuzzer) (*corev1.Namespace, func(), error) {
-	namespace := &corev1.Namespace{}
-	nnID, err := f.GetStringFrom(lettersAndNumbers, 10)
-	if err != nil {
-		return namespace, func() {}, err
-	}
-	namespace.ObjectMeta = metav1.ObjectMeta{Name: "git-repository-test" + nnID}
-	err = k8sClient.Create(context.Background(), namespace)
-	if err != nil {
-		return namespace, func() {}, err
-	}
-	return namespace, func() {
-		k8sClient.Delete(context.Background(), namespace)
-	}, nil
-}
-
-// createGitServer is a helper function to create a git server.
-func createGitServer(f *fuzz.ConsumeFuzzer) (*url.URL, func()) {
-	repoID, err := f.GetStringFrom(lettersAndNumbers, 10)
-	if err != nil {
-		return &url.URL{}, func() {}
-	}
-	gitServer, err := gittestserver.NewTempGitServer()
-	if err != nil {
-		panic(err)
-	}
-	gitServer.AutoCreate()
-	defer os.RemoveAll(gitServer.Root())
-
-	utilruntime.Must(gitServer.StartHTTPS(examplePublicKey, examplePrivateKey, exampleCA, "example.com"))
-
-	u, err := url.Parse(gitServer.HTTPAddress())
-	if err != nil {
-		panic(err)
-	}
-	u.Path = path.Join(u.Path, fmt.Sprintf("repository-%s.git", repoID))
-	return u, func() { gitServer.StopHTTP() }
-}
-
-// pushFilesToGit is a helper function to push files to a git server.
-func pushFilesToGit(gitrepo *git.Repository, wt *git.Worktree, gitServerURL string) (plumbing.Hash, error) {
-	commit, err := wt.Commit("Sample", &git.CommitOptions{Author: &object.Signature{
-		Name:  "John Doe",
-		Email: "john@example.com",
-		When:  time.Now(),
-	}})
-	if err != nil {
-		return plumbing.ZeroHash, err
-	}
-	hRef := plumbing.NewHashReference(plumbing.ReferenceName("refs/heads/some-branch"), commit)
-	err = gitrepo.Storer.SetReference(hRef)
-	if err != nil {
-		return plumbing.ZeroHash, err
-	}
-
-	remote, err := gitrepo.CreateRemote(&config.RemoteConfig{
-		Name: "origin",
-		URLs: []string{gitServerURL},
-	})
-	if err != nil {
-		return plumbing.ZeroHash, err
-	}
-	err = remote.Push(&git.PushOptions{
-		RefSpecs: []config.RefSpec{"refs/heads/*:refs/heads/*", "refs/tags/*:refs/tags/*"},
-	})
-	if err != nil {
-		return plumbing.ZeroHash, err
-	}
-	return commit, nil
-
-}
-
-// createRandomFiles is a helper function to create files in a billy.Filesystem.
-func createRandomFiles(f *fuzz.ConsumeFuzzer, fs billy.Filesystem, wt *git.Worktree) error {
-	numberOfFiles, err := f.GetInt()
-	if err != nil {
-		return err
-	}
-	maxNumberOfFiles := 4000 // This number is completely arbitrary
-	if numberOfFiles%maxNumberOfFiles == 0 {
-		return errors.New("We don't want to create 0 files...")
-	}
-
-	for i := 0; i < numberOfFiles%maxNumberOfFiles; i++ {
-		dirPath, err := f.GetString()
-		if err != nil {
-			return err
-		}
-
-		// Check for ".." cases
-		if strings.Contains(dirPath, "..") {
-			return errors.New("Dir contains '..'")
-		}
-
-		err = fs.MkdirAll(dirPath, 0o700)
-		if err != nil {
-			return errors.New("Could not create the subDir")
-		}
-		fileName, err := f.GetString()
-		if err != nil {
-			return errors.New("Could not get fileName")
-		}
-		fullFilePath := fs.Join(dirPath, fileName)
-
-		fileContents, err := f.GetBytes()
-		if err != nil {
-			return errors.New("Could not create the subDir")
-		}
-
-		createdFile, err := fs.Create(fullFilePath)
-		if err != nil {
-			return errors.New("Could not create the subDir")
-		}
-		_, err = createdFile.Write(fileContents)
-		if err != nil {
-			createdFile.Close()
-			return errors.New("Could not create the subDir")
-		}
-		createdFile.Close()
-		_, err = wt.Add(fullFilePath)
-		if err != nil {
-			panic(err)
-		}
-		noOfCreatedFiles++
-	}
-	return nil
-}
-
-func envtestBinVersion() string {
-	if binVersion := os.Getenv("ENVTEST_BIN_VERSION"); binVersion != "" {
-		return binVersion
-	}
-	return defaultBinVersion
-}
-
-func ensureDependencies() error {
-	if _, err := os.Stat("/.dockerenv"); os.IsNotExist(err) {
-		return nil
-	}
-
-	if os.Getenv("KUBEBUILDER_ASSETS") == "" {
-		binVersion := envtestBinVersion()
-		cmd := exec.Command("/usr/bin/bash", "-c", fmt.Sprintf(`go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest && \
-		/root/go/bin/setup-envtest use -p path %s`, binVersion))
-
-		cmd.Env = append(os.Environ(), "GOPATH=/root/go")
-		assetsPath, err := cmd.Output()
-		if err != nil {
-			return err
-		}
-		os.Setenv("KUBEBUILDER_ASSETS", string(assetsPath))
-	}
-
-	// Output all embedded testdata files
-	embedDirs := []string{"testdata/crd", "testdata/certs"}
-	for _, dir := range embedDirs {
-		err := os.MkdirAll(dir, 0o700)
-		if err != nil {
-			return fmt.Errorf("mkdir %s: %v", dir, err)
-		}
-
-		templates, err := fs.ReadDir(testFiles, dir)
-		if err != nil {
-			return fmt.Errorf("reading embedded dir: %v", err)
-		}
-
-		for _, template := range templates {
-			fileName := fmt.Sprintf("%s/%s", dir, template.Name())
-			fmt.Println(fileName)
-
-			data, err := testFiles.ReadFile(fileName)
-			if err != nil {
-				return fmt.Errorf("reading embedded file %s: %v", fileName, err)
-			}
-
-			os.WriteFile(fileName, data, 0o600)
-			if err != nil {
-				return fmt.Errorf("writing %s: %v", fileName, err)
-			}
-		}
-	}
-
-	startEnvServer(func(m manager.Manager) {
-		utilruntime.Must((&GitRepositoryReconciler{
-			Client:  m.GetClient(),
-			Storage: storage,
-		}).SetupWithManagerAndOptions(m, GitRepositoryReconcilerOptions{
-			RateLimiter: controller.GetDefaultRateLimiter(),
-		}))
-	})
-
-	return nil
-}
-
-func startEnvServer(setupReconcilers func(manager.Manager)) *envtest.Environment {
-	testEnv := &envtest.Environment{
-		CRDDirectoryPaths: []string{filepath.Join("testdata", "crd")},
-	}
-	fmt.Println("Starting the test environment")
-	cfg, err := testEnv.Start()
-	if err != nil {
-		panic(fmt.Sprintf("Failed to start the test environment manager: %v", err))
-	}
-
-	utilruntime.Must(loadExampleKeys())
-	utilruntime.Must(sourcev1.AddToScheme(scheme.Scheme))
-
-	tmpStoragePath, err := os.MkdirTemp("", "source-controller-storage-")
-	if err != nil {
-		panic(err)
-	}
-	defer os.RemoveAll(tmpStoragePath)
-	storage, err = NewStorage(tmpStoragePath, "localhost:5050", time.Minute*1, 2)
-	if err != nil {
-		panic(err)
-	}
-	// serve artifacts from the filesystem, as done in main.go
-	fs := http.FileServer(http.Dir(tmpStoragePath))
-	http.Handle("/", fs)
-	go http.ListenAndServe(":5050", nil)
-
-	cert, err := tls.X509KeyPair(examplePublicKey, examplePrivateKey)
-	if err != nil {
-		panic(err)
-	}
-
-	caCertPool := x509.NewCertPool()
-	caCertPool.AppendCertsFromPEM(exampleCA)
-
-	tlsConfig := &tls.Config{
-		Certificates: []tls.Certificate{cert},
-		RootCAs:      caCertPool,
-	}
-	tlsConfig.BuildNameToCertificate()
-
-	var transport = httptransport.NewClient(&http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: tlsConfig,
-		},
-	})
-	gitclient.InstallProtocol("https", transport)
-
-	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
-	if err != nil {
-		panic(err)
-	}
-	if k8sClient == nil {
-		panic("cfg is nil but should not be")
-	}
-
-	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme: scheme.Scheme,
-	})
-	if err != nil {
-		panic(err)
-	}
-
-	setupReconcilers(k8sManager)
-
-	time.Sleep(2 * time.Second)
-	go func() {
-		fmt.Println("Starting k8sManager...")
-		utilruntime.Must(k8sManager.Start(context.TODO()))
-	}()
-
-	return testEnv
-}
+//
+//import (
+//	"context"
+//	"crypto/tls"
+//	"crypto/x509"
+//	"embed"
+//	"errors"
+//	"fmt"
+//	"io/fs"
+//	"net/http"
+//	"net/url"
+//	"os"
+//	"os/exec"
+//	"path"
+//	"path/filepath"
+//	"strings"
+//	"sync"
+//	"testing"
+//	"time"
+//
+//	fuzz "github.com/AdaLogics/go-fuzz-headers"
+//	"github.com/go-git/go-billy/v5"
+//	"github.com/go-git/go-billy/v5/memfs"
+//	"github.com/go-git/go-git/v5"
+//	"github.com/go-git/go-git/v5/config"
+//	"github.com/go-git/go-git/v5/plumbing"
+//	"github.com/go-git/go-git/v5/plumbing/object"
+//	gitclient "github.com/go-git/go-git/v5/plumbing/transport/client"
+//	httptransport "github.com/go-git/go-git/v5/plumbing/transport/http"
+//	"github.com/go-git/go-git/v5/storage/memory"
+//	corev1 "k8s.io/api/core/v1"
+//	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+//	"k8s.io/apimachinery/pkg/types"
+//	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+//	"k8s.io/client-go/kubernetes/scheme"
+//	"k8s.io/client-go/rest"
+//	ctrl "sigs.k8s.io/controller-runtime"
+//	"sigs.k8s.io/controller-runtime/pkg/client"
+//	"sigs.k8s.io/controller-runtime/pkg/envtest"
+//	"sigs.k8s.io/controller-runtime/pkg/manager"
+//
+//	"github.com/fluxcd/pkg/gittestserver"
+//	"github.com/fluxcd/pkg/runtime/controller"
+//	"github.com/fluxcd/pkg/runtime/testenv"
+//
+//	sourcev1 "github.com/fluxcd/source-controller/api/v1"
+//)
+//
+//var (
+//	noOfCreatedFiles = 0
+//	interval         = time.Millisecond * 10
+//	indexInterval    = time.Millisecond * 10
+//	pullInterval     = time.Second * 3
+//	initter          sync.Once
+//	gitServer        *gittestserver.GitServer
+//	k8sClient        client.Client
+//	cfg              *rest.Config
+//	testEnv          *testenv.Environment
+//
+//	storage *Storage
+//
+//	examplePublicKey  []byte
+//	examplePrivateKey []byte
+//	exampleCA         []byte
+//)
+//
+////go:embed testdata/crd/*.yaml
+////go:embed testdata/certs/*
+//var testFiles embed.FS
+//
+//const (
+//	defaultBinVersion     = "1.24"
+//	lettersAndNumbers     = "abcdefghijklmnopqrstuvwxyz123456789"
+//	lettersNumbersAndDash = "abcdefghijklmnopqrstuvwxyz123456789-"
+//)
+//
+//// FuzzRandomGitFiles implements a fuzzer that
+//// targets the GitRepository reconciler.
+//func FuzzRandomGitFiles(f *testing.F) {
+//	f.Fuzz(func(t *testing.T, data []byte) {
+//		initter.Do(func() {
+//			utilruntime.Must(ensureDependencies())
+//		})
+//
+//		f := fuzz.NewConsumer(data)
+//		namespace, deleteNamespace, err := createNamespace(f)
+//		if err != nil {
+//			return
+//		}
+//		defer deleteNamespace()
+//
+//		gitServerURL, stopGitServer := createGitServer(f)
+//		defer stopGitServer()
+//
+//		fs := memfs.New()
+//		gitrepo, err := git.Init(memory.NewStorage(), fs)
+//		if err != nil {
+//			panic(err)
+//		}
+//		wt, err := gitrepo.Worktree()
+//		if err != nil {
+//			panic(err)
+//		}
+//
+//		// Create random files for the git source
+//		err = createRandomFiles(f, fs, wt)
+//		if err != nil {
+//			return
+//		}
+//
+//		commit, err := pushFilesToGit(gitrepo, wt, gitServerURL.String())
+//		if err != nil {
+//			return
+//		}
+//		created, err := createGitRepository(f, gitServerURL.String(), commit.String(), namespace.Name)
+//		if err != nil {
+//			return
+//		}
+//		err = k8sClient.Create(context.Background(), created)
+//		if err != nil {
+//			return
+//		}
+//		defer k8sClient.Delete(context.Background(), created)
+//
+//		// Let the reconciler do its thing:
+//		time.Sleep(60 * time.Millisecond)
+//	})
+//}
+//
+//// FuzzGitResourceObject implements a fuzzer that targets
+//// the GitRepository reconciler.
+//func FuzzGitResourceObject(f *testing.F) {
+//	f.Fuzz(func(t *testing.T, data []byte) {
+//		initter.Do(func() {
+//			utilruntime.Must(ensureDependencies())
+//		})
+//
+//		f := fuzz.NewConsumer(data)
+//
+//		// Create this early because if it fails, then the fuzzer
+//		// does not need to proceed.
+//		repository := &sourcev1.GitRepository{}
+//		err := f.GenerateStruct(repository)
+//		if err != nil {
+//			return
+//		}
+//
+//		metaName, err := f.GetStringFrom(lettersNumbersAndDash, 59)
+//		if err != nil {
+//			return
+//		}
+//
+//		gitServerURL, stopGitServer := createGitServer(f)
+//		defer stopGitServer()
+//
+//		fs := memfs.New()
+//		gitrepo, err := git.Init(memory.NewStorage(), fs)
+//		if err != nil {
+//			return
+//		}
+//		wt, err := gitrepo.Worktree()
+//		if err != nil {
+//			return
+//		}
+//
+//		// Add a file
+//		ff, _ := fs.Create("fixture")
+//		_ = ff.Close()
+//		_, err = wt.Add(fs.Join("fixture"))
+//		if err != nil {
+//			return
+//		}
+//
+//		commit, err := pushFilesToGit(gitrepo, wt, gitServerURL.String())
+//		if err != nil {
+//			return
+//		}
+//
+//		namespace, deleteNamespace, err := createNamespace(f)
+//		if err != nil {
+//			return
+//		}
+//		defer deleteNamespace()
+//
+//		repository.Spec.URL = gitServerURL.String()
+//		repository.Spec.Verification.Mode = "head"
+//		repository.Spec.SecretRef = nil
+//
+//		reference := &sourcev1.GitRepositoryRef{Branch: "some-branch"}
+//		reference.Commit = strings.Replace(reference.Commit, "<commit>", commit.String(), 1)
+//		repository.Spec.Reference = reference
+//
+//		repository.ObjectMeta = metav1.ObjectMeta{
+//			Name:      metaName,
+//			Namespace: namespace.Name,
+//		}
+//		err = k8sClient.Create(context.Background(), repository)
+//		if err != nil {
+//			return
+//		}
+//		defer k8sClient.Delete(context.Background(), repository)
+//
+//		// Let the reconciler do its thing.
+//		time.Sleep(50 * time.Millisecond)
+//	})
+//}
+//
+//func loadExampleKeys() (err error) {
+//	examplePublicKey, err = os.ReadFile("testdata/certs/server.pem")
+//	if err != nil {
+//		return err
+//	}
+//	examplePrivateKey, err = os.ReadFile("testdata/certs/server-key.pem")
+//	if err != nil {
+//		return err
+//	}
+//	exampleCA, err = os.ReadFile("testdata/certs/ca.pem")
+//	return err
+//}
+//
+//// createGitRepository is a helper function to create GitRepository objects.
+//func createGitRepository(f *fuzz.ConsumeFuzzer, specUrl, commit, namespaceName string) (*sourcev1.GitRepository, error) {
+//	reference := &sourcev1.GitRepositoryRef{Branch: "some-branch"}
+//	reference.Commit = strings.Replace(reference.Commit, "<commit>", commit, 1)
+//	nnID, err := f.GetStringFrom(lettersAndNumbers, 10)
+//	if err != nil {
+//		return &sourcev1.GitRepository{}, err
+//	}
+//	key := types.NamespacedName{
+//		Name:      fmt.Sprintf("git-ref-test-%s", nnID),
+//		Namespace: namespaceName,
+//	}
+//
+//	return &sourcev1.GitRepository{
+//		ObjectMeta: metav1.ObjectMeta{
+//			Name:      key.Name,
+//			Namespace: key.Namespace,
+//		},
+//		Spec: sourcev1.GitRepositorySpec{
+//			URL:       specUrl,
+//			Interval:  metav1.Duration{Duration: indexInterval},
+//			Reference: reference,
+//		},
+//	}, nil
+//}
+//
+//// createNamespace is a helper function to create kubernetes namespaces.
+//func createNamespace(f *fuzz.ConsumeFuzzer) (*corev1.Namespace, func(), error) {
+//	namespace := &corev1.Namespace{}
+//	nnID, err := f.GetStringFrom(lettersAndNumbers, 10)
+//	if err != nil {
+//		return namespace, func() {}, err
+//	}
+//	namespace.ObjectMeta = metav1.ObjectMeta{Name: "git-repository-test" + nnID}
+//	err = k8sClient.Create(context.Background(), namespace)
+//	if err != nil {
+//		return namespace, func() {}, err
+//	}
+//	return namespace, func() {
+//		k8sClient.Delete(context.Background(), namespace)
+//	}, nil
+//}
+//
+//// createGitServer is a helper function to create a git server.
+//func createGitServer(f *fuzz.ConsumeFuzzer) (*url.URL, func()) {
+//	repoID, err := f.GetStringFrom(lettersAndNumbers, 10)
+//	if err != nil {
+//		return &url.URL{}, func() {}
+//	}
+//	gitServer, err := gittestserver.NewTempGitServer()
+//	if err != nil {
+//		panic(err)
+//	}
+//	gitServer.AutoCreate()
+//	defer os.RemoveAll(gitServer.Root())
+//
+//	utilruntime.Must(gitServer.StartHTTPS(examplePublicKey, examplePrivateKey, exampleCA, "example.com"))
+//
+//	u, err := url.Parse(gitServer.HTTPAddress())
+//	if err != nil {
+//		panic(err)
+//	}
+//	u.Path = path.Join(u.Path, fmt.Sprintf("repository-%s.git", repoID))
+//	return u, func() { gitServer.StopHTTP() }
+//}
+//
+//// pushFilesToGit is a helper function to push files to a git server.
+//func pushFilesToGit(gitrepo *git.Repository, wt *git.Worktree, gitServerURL string) (plumbing.Hash, error) {
+//	commit, err := wt.Commit("Sample", &git.CommitOptions{Author: &object.Signature{
+//		Name:  "John Doe",
+//		Email: "john@example.com",
+//		When:  time.Now(),
+//	}})
+//	if err != nil {
+//		return plumbing.ZeroHash, err
+//	}
+//	hRef := plumbing.NewHashReference(plumbing.ReferenceName("refs/heads/some-branch"), commit)
+//	err = gitrepo.Storer.SetReference(hRef)
+//	if err != nil {
+//		return plumbing.ZeroHash, err
+//	}
+//
+//	remote, err := gitrepo.CreateRemote(&config.RemoteConfig{
+//		Name: "origin",
+//		URLs: []string{gitServerURL},
+//	})
+//	if err != nil {
+//		return plumbing.ZeroHash, err
+//	}
+//	err = remote.Push(&git.PushOptions{
+//		RefSpecs: []config.RefSpec{"refs/heads/*:refs/heads/*", "refs/tags/*:refs/tags/*"},
+//	})
+//	if err != nil {
+//		return plumbing.ZeroHash, err
+//	}
+//	return commit, nil
+//
+//}
+//
+//// createRandomFiles is a helper function to create files in a billy.Filesystem.
+//func createRandomFiles(f *fuzz.ConsumeFuzzer, fs billy.Filesystem, wt *git.Worktree) error {
+//	numberOfFiles, err := f.GetInt()
+//	if err != nil {
+//		return err
+//	}
+//	maxNumberOfFiles := 4000 // This number is completely arbitrary
+//	if numberOfFiles%maxNumberOfFiles == 0 {
+//		return errors.New("We don't want to create 0 files...")
+//	}
+//
+//	for i := 0; i < numberOfFiles%maxNumberOfFiles; i++ {
+//		dirPath, err := f.GetString()
+//		if err != nil {
+//			return err
+//		}
+//
+//		// Check for ".." cases
+//		if strings.Contains(dirPath, "..") {
+//			return errors.New("Dir contains '..'")
+//		}
+//
+//		err = fs.MkdirAll(dirPath, 0o700)
+//		if err != nil {
+//			return errors.New("Could not create the subDir")
+//		}
+//		fileName, err := f.GetString()
+//		if err != nil {
+//			return errors.New("Could not get fileName")
+//		}
+//		fullFilePath := fs.Join(dirPath, fileName)
+//
+//		fileContents, err := f.GetBytes()
+//		if err != nil {
+//			return errors.New("Could not create the subDir")
+//		}
+//
+//		createdFile, err := fs.Create(fullFilePath)
+//		if err != nil {
+//			return errors.New("Could not create the subDir")
+//		}
+//		_, err = createdFile.Write(fileContents)
+//		if err != nil {
+//			createdFile.Close()
+//			return errors.New("Could not create the subDir")
+//		}
+//		createdFile.Close()
+//		_, err = wt.Add(fullFilePath)
+//		if err != nil {
+//			panic(err)
+//		}
+//		noOfCreatedFiles++
+//	}
+//	return nil
+//}
+//
+//func envtestBinVersion() string {
+//	if binVersion := os.Getenv("ENVTEST_BIN_VERSION"); binVersion != "" {
+//		return binVersion
+//	}
+//	return defaultBinVersion
+//}
+//
+//func ensureDependencies() error {
+//	if _, err := os.Stat("/.dockerenv"); os.IsNotExist(err) {
+//		return nil
+//	}
+//
+//	if os.Getenv("KUBEBUILDER_ASSETS") == "" {
+//		binVersion := envtestBinVersion()
+//		cmd := exec.Command("/usr/bin/bash", "-c", fmt.Sprintf(`go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest && \
+//		/root/go/bin/setup-envtest use -p path %s`, binVersion))
+//
+//		cmd.Env = append(os.Environ(), "GOPATH=/root/go")
+//		assetsPath, err := cmd.Output()
+//		if err != nil {
+//			return err
+//		}
+//		os.Setenv("KUBEBUILDER_ASSETS", string(assetsPath))
+//	}
+//
+//	// Output all embedded testdata files
+//	embedDirs := []string{"testdata/crd", "testdata/certs"}
+//	for _, dir := range embedDirs {
+//		err := os.MkdirAll(dir, 0o700)
+//		if err != nil {
+//			return fmt.Errorf("mkdir %s: %v", dir, err)
+//		}
+//
+//		templates, err := fs.ReadDir(testFiles, dir)
+//		if err != nil {
+//			return fmt.Errorf("reading embedded dir: %v", err)
+//		}
+//
+//		for _, template := range templates {
+//			fileName := fmt.Sprintf("%s/%s", dir, template.Name())
+//			fmt.Println(fileName)
+//
+//			data, err := testFiles.ReadFile(fileName)
+//			if err != nil {
+//				return fmt.Errorf("reading embedded file %s: %v", fileName, err)
+//			}
+//
+//			os.WriteFile(fileName, data, 0o600)
+//			if err != nil {
+//				return fmt.Errorf("writing %s: %v", fileName, err)
+//			}
+//		}
+//	}
+//
+//	startEnvServer(func(m manager.Manager) {
+//		utilruntime.Must((&GitRepositoryReconciler{
+//			Client:  m.GetClient(),
+//			Storage: storage,
+//		}).SetupWithManagerAndOptions(m, GitRepositoryReconcilerOptions{
+//			RateLimiter: controller.GetDefaultRateLimiter(),
+//		}))
+//	})
+//
+//	return nil
+//}
+//
+//func startEnvServer(setupReconcilers func(manager.Manager)) *envtest.Environment {
+//	testEnv := &envtest.Environment{
+//		CRDDirectoryPaths: []string{filepath.Join("testdata", "crd")},
+//	}
+//	fmt.Println("Starting the test environment")
+//	cfg, err := testEnv.Start()
+//	if err != nil {
+//		panic(fmt.Sprintf("Failed to start the test environment manager: %v", err))
+//	}
+//
+//	utilruntime.Must(loadExampleKeys())
+//	utilruntime.Must(sourcev1.AddToScheme(scheme.Scheme))
+//
+//	tmpStoragePath, err := os.MkdirTemp("", "source-controller-storage-")
+//	if err != nil {
+//		panic(err)
+//	}
+//	defer os.RemoveAll(tmpStoragePath)
+//	storage, err = NewStorage(tmpStoragePath, "localhost:5050", time.Minute*1, 2)
+//	if err != nil {
+//		panic(err)
+//	}
+//	// serve artifacts from the filesystem, as done in main.go
+//	fs := http.FileServer(http.Dir(tmpStoragePath))
+//	http.Handle("/", fs)
+//	go http.ListenAndServe(":5050", nil)
+//
+//	cert, err := tls.X509KeyPair(examplePublicKey, examplePrivateKey)
+//	if err != nil {
+//		panic(err)
+//	}
+//
+//	caCertPool := x509.NewCertPool()
+//	caCertPool.AppendCertsFromPEM(exampleCA)
+//
+//	tlsConfig := &tls.Config{
+//		Certificates: []tls.Certificate{cert},
+//		RootCAs:      caCertPool,
+//	}
+//	tlsConfig.BuildNameToCertificate()
+//
+//	var transport = httptransport.NewClient(&http.Client{
+//		Transport: &http.Transport{
+//			TLSClientConfig: tlsConfig,
+//		},
+//	})
+//	gitclient.InstallProtocol("https", transport)
+//
+//	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+//	if err != nil {
+//		panic(err)
+//	}
+//	if k8sClient == nil {
+//		panic("cfg is nil but should not be")
+//	}
+//
+//	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
+//		Scheme: scheme.Scheme,
+//	})
+//	if err != nil {
+//		panic(err)
+//	}
+//
+//	setupReconcilers(k8sManager)
+//
+//	time.Sleep(2 * time.Second)
+//	go func() {
+//		fmt.Println("Starting k8sManager...")
+//		utilruntime.Must(k8sManager.Start(context.TODO()))
+//	}()
+//
+//	return testEnv
+//}

--- a/internal/controller/gitrepository_controller_test.go
+++ b/internal/controller/gitrepository_controller_test.go
@@ -2654,7 +2654,7 @@ func TestGitRepositoryReconciler_fetchIncludes(t *testing.T) {
 			},
 			wantErr: true,
 			assertConditions: []metav1.Condition{
-				*conditions.TrueCondition(sourcev1.IncludeUnavailableCondition, "NotFound", "could not get resource for include 'a': gitrepositories.source.toolkit.fluxcd.io \"a\" not found"),
+				*conditions.TrueCondition(sourcev1.IncludeUnavailableCondition, "NotFound", "could not get resource for include 'a': gitrepositories.cd.qdrant.io \"a\" not found"),
 			},
 		},
 		{

--- a/internal/controller/helmchart_controller.go
+++ b/internal/controller/helmchart_controller.go
@@ -122,9 +122,9 @@ var helmChartFailConditions = []string{
 	sourcev1.StorageOperationFailedCondition,
 }
 
-// +kubebuilder:rbac:groups=source.toolkit.fluxcd.io,resources=helmcharts,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=source.toolkit.fluxcd.io,resources=helmcharts/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=source.toolkit.fluxcd.io,resources=helmcharts/finalizers,verbs=get;create;update;patch;delete
+// +kubebuilder:rbac:groups=cd.qdrant.io,resources=helmcharts,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=cd.qdrant.io,resources=helmcharts/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=cd.qdrant.io,resources=helmcharts/finalizers,verbs=get;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
 // HelmChartReconciler reconciles a HelmChart object

--- a/internal/controller/helmchart_controller.go
+++ b/internal/controller/helmchart_controller.go
@@ -137,6 +137,7 @@ type HelmChartReconciler struct {
 	Storage                 *Storage
 	Getters                 helmgetter.Providers
 	ControllerName          string
+	LeaderElection          *bool
 
 	Cache *cache.Cache
 	TTL   time.Duration
@@ -196,7 +197,8 @@ func (r *HelmChartReconciler) SetupWithManagerAndOptions(ctx context.Context, mg
 			builder.WithPredicates(SourceRevisionChangePredicate{}),
 		).
 		WithOptions(controller.Options{
-			RateLimiter: opts.RateLimiter,
+			RateLimiter:        opts.RateLimiter,
+			NeedLeaderElection: r.LeaderElection,
 		}).
 		Complete(r)
 }

--- a/internal/controller/helmchart_controller_test.go
+++ b/internal/controller/helmchart_controller_test.go
@@ -670,12 +670,12 @@ func TestHelmChartReconciler_reconcileSource(t *testing.T) {
 				conditions.MarkUnknown(obj, meta.ReadyCondition, "foo", "bar")
 			},
 			want:    sreconcile.ResultEmpty,
-			wantErr: &serror.Generic{Err: errors.New("gitrepositories.source.toolkit.fluxcd.io \"unavailable\" not found")},
+			wantErr: &serror.Generic{Err: errors.New("gitrepositories.cd.qdrant.io \"unavailable\" not found")},
 			assertFunc: func(g *WithT, build chart.Build, obj sourcev1.HelmChart) {
 				g.Expect(build.Complete()).To(BeFalse())
 
 				g.Expect(obj.Status.Conditions).To(conditions.MatchConditions([]metav1.Condition{
-					*conditions.TrueCondition(sourcev1.FetchFailedCondition, "SourceUnavailable", "failed to get source: gitrepositories.source.toolkit.fluxcd.io \"unavailable\" not found"),
+					*conditions.TrueCondition(sourcev1.FetchFailedCondition, "SourceUnavailable", "failed to get source: gitrepositories.cd.qdrant.io \"unavailable\" not found"),
 					*conditions.TrueCondition(meta.ReconcilingCondition, meta.ProgressingReason, "foo"),
 					*conditions.UnknownCondition(meta.ReadyCondition, "foo", "bar"),
 				}))

--- a/internal/controller/helmrepository_controller.go
+++ b/internal/controller/helmrepository_controller.go
@@ -111,6 +111,7 @@ type HelmRepositoryReconciler struct {
 	Getters        helmgetter.Providers
 	Storage        *Storage
 	ControllerName string
+	LeaderElection *bool
 
 	Cache *cache.Cache
 	TTL   time.Duration
@@ -145,7 +146,8 @@ func (r *HelmRepositoryReconciler) SetupWithManagerAndOptions(mgr ctrl.Manager, 
 			),
 		).
 		WithOptions(controller.Options{
-			RateLimiter: opts.RateLimiter,
+			RateLimiter:        opts.RateLimiter,
+			NeedLeaderElection: r.LeaderElection,
 		}).
 		Complete(r)
 }

--- a/internal/controller/helmrepository_controller.go
+++ b/internal/controller/helmrepository_controller.go
@@ -97,9 +97,9 @@ var helmRepositoryFailConditions = []string{
 	sourcev1.StorageOperationFailedCondition,
 }
 
-// +kubebuilder:rbac:groups=source.toolkit.fluxcd.io,resources=helmrepositories,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=source.toolkit.fluxcd.io,resources=helmrepositories/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=source.toolkit.fluxcd.io,resources=helmrepositories/finalizers,verbs=get;create;update;patch;delete
+// +kubebuilder:rbac:groups=cd.qdrant.io,resources=helmrepositories,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=cd.qdrant.io,resources=helmrepositories/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=cd.qdrant.io,resources=helmrepositories/finalizers,verbs=get;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
 // HelmRepositoryReconciler reconciles a v1.HelmRepository object.

--- a/internal/controller/ocirepository_controller.go
+++ b/internal/controller/ocirepository_controller.go
@@ -171,9 +171,9 @@ func (r *OCIRepositoryReconciler) SetupWithManagerAndOptions(mgr ctrl.Manager, o
 		Complete(r)
 }
 
-// +kubebuilder:rbac:groups=source.toolkit.fluxcd.io,resources=ocirepositories,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=source.toolkit.fluxcd.io,resources=ocirepositories/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=source.toolkit.fluxcd.io,resources=ocirepositories/finalizers,verbs=get;create;update;patch;delete
+// +kubebuilder:rbac:groups=cd.qdrant.io,resources=ocirepositories,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=cd.qdrant.io,resources=ocirepositories/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=cd.qdrant.io,resources=ocirepositories/finalizers,verbs=get;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
 func (r *OCIRepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, retErr error) {

--- a/pkg/gcp/gcp_test.go
+++ b/pkg/gcp/gcp_test.go
@@ -466,7 +466,7 @@ func getBucket() *raw.Bucket {
 
 func getObjectFile() string {
 	return `
-	apiVersion: source.toolkit.fluxcd.io/v1beta1
+	apiVersion: cd.qdrant.io/v1beta1
 	kind: Bucket
 	metadata:
 	  name: podinfo

--- a/pkg/minio/minio_test.go
+++ b/pkg/minio/minio_test.go
@@ -51,7 +51,7 @@ import (
 
 const (
 	objectName string = "test.yaml"
-	objectEtag string = "2020beab5f1711919157756379622d1d"
+	objectEtag string = "db7bb43f096f2780bd9215ca3f966375"
 )
 
 var (
@@ -556,7 +556,7 @@ func removeObjectFromBucket(ctx context.Context) {
 
 func getObjectFile() string {
 	return `
-	apiVersion: source.toolkit.fluxcd.io/v1beta2
+	apiVersion: cd.qdrant.io/v1beta2
 	kind: Bucket
 	metadata:
 	  name: podinfo

--- a/scripts/rename-api-groups.sh
+++ b/scripts/rename-api-groups.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+set -e
+
+declare -A replacements
+
+replacements=(
+    ["source.toolkit.fluxcd.io"]="cd.qdrant.io"
+    ["domain: toolkit.fluxcd.io"]="domain: qdrant.io"
+    ["finalizers.fluxcd.io"]="finalizers.qdrant.io"
+    ["group: source"]="group: cd"
+    ["shortName=gitrepo"]="shortName=qdrantgitrepo"
+    ["shortName=hc"]="shortName=qdranthc"
+    ["shortName=helmrepo"]="shortName=qdranthelmrepo"
+    ["shortName=ocirepo"]="shortName=qdrantocirepo"
+    ["group: cd.toolkit.fluxcd.io"]="group: cd.qdrant.io"
+)
+
+replace_files_content() {
+    for pattern in "${!replacements[@]}"; do
+        echo "Renaming '$pattern' to '${replacements[$pattern]}'"
+        find . -type f \( -name '*.go' -o -name '*.yml' -o -name '*.yaml' -o -path './docs/*.md' -o -name 'PROJECT' \) | xargs sed -i '' "s/$pattern/${replacements[$pattern]}/g"
+    done
+
+    # special ones (multiline)
+    find . -type f \( -name '*.go' -o -name '*.yml' -o -name '*.yaml' -o -path './docs/*.md' -o -name 'PROJECT' \) | xargs sed -i '' '/shortNames:/,/^ *-/s/- gitrepo/- qdrantgitrepo/'
+    find . -type f \( -name '*.go' -o -name '*.yml' -o -name '*.yaml' -o -path './docs/*.md' -o -name 'PROJECT' \) | xargs sed -i '' '/shortNames:/,/^ *-/s/- hc/- qdranthc/'
+    find . -type f \( -name '*.go' -o -name '*.yml' -o -name '*.yaml' -o -path './docs/*.md' -o -name 'PROJECT' \) | xargs sed -i '' '/shortNames:/,/^ *-/s/- helmrepo/- qdranthelmrepo/'
+    find . -type f \( -name '*.go' -o -name '*.yml' -o -name '*.yaml' -o -path './docs/*.md' -o -name 'PROJECT' \) | xargs sed -i '' '/shortNames:/,/^ *-/s/- ocirepo/- qdrantocirepo/'
+}
+
+copy_crd_base_files() {
+    old_pattern="source.toolkit.fluxcd.io"
+    new_pattern="cd.qdrant.io"
+    for file in config/crd/bases/*.yaml; do
+        new_filename=`echo $file | sed s/$old_pattern/$new_pattern/g`
+        echo "Copying '$file' to '$new_filename'"
+        cp $file $new_filename || true
+    done
+}
+
+# For some reason in the original patch we were keeping the original files. We
+# do the same here. We use git restore to undo the changes made by the call to
+# `replace_files_content`.
+restore_original_crd_base_files() {
+    git restore config/crd/bases/source*
+}
+
+replace_files_content
+copy_crd_base_files
+restore_original_crd_base_files


### PR DESCRIPTION
Related: https://github.com/qdrant/cloud-pm/issues/1282

Currently, `main` branch is up to date with `upstream/main`. This PR contains:
- The original changes we did to the project.
- More renaming of the api groups. I tried to unify the renaming rules we were manually applying and put them in a script. Besides automating the process, we have it as a reference of what we're modifying. I applied consistently through all the project.
- Changes to the adapter code to make it work with the latest versions of k8s (`v0.3.1`). 
- Finally, I added some instructions in the readme about how to keep the project up to date and the script to rename the api groups. 